### PR TITLE
harness: record run and step outcomes at the terminal step

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.35.3",
+    "version": "0.35.4",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/__tests__/setup/metrics.ts
+++ b/harness/src/__tests__/setup/metrics.ts
@@ -1,0 +1,60 @@
+/**
+ * In-memory OTel metrics capture for a test that asserts on what a record site
+ * exported. The harness binds its instruments to the GLOBAL `MeterProvider` at
+ * first use (`lib/metrics.ts`), so the capture registers one, resets the
+ * memoised instruments so they rebind to it, and undoes both on `dispose`.
+ */
+
+import { type Attributes, metrics } from "@opentelemetry/api";
+import {
+    AggregationTemporality,
+    type HistogramMetricData,
+    InMemoryMetricExporter,
+    MeterProvider,
+    type MetricData,
+    PeriodicExportingMetricReader,
+    type SumMetricData,
+} from "@opentelemetry/sdk-metrics";
+
+import { __resetMetricsForTest } from "../../lib/metrics.js";
+
+export interface MetricsCapture {
+    /** `[attributes, value]` of each data point of a counter; `[]` when the instrument exported nothing. */
+    sums(name: string): Promise<Array<[Attributes, number]>>;
+    /** `[attributes, {count, sum}]` of each data point of a histogram; `[]` when the instrument exported nothing. */
+    histograms(name: string): Promise<Array<[Attributes, { count: number; sum: number | undefined }]>>;
+    /** Shut the provider down and unbind the global meter provider. */
+    dispose(): Promise<void>;
+}
+
+export function captureMetrics(): MetricsCapture {
+    __resetMetricsForTest();
+    const exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+    const provider = new MeterProvider({ readers: [new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 3_600_000 })] });
+    metrics.setGlobalMeterProvider(provider);
+
+    const find = async (name: string): Promise<MetricData | undefined> => {
+        await provider.forceFlush();
+        return exporter
+            .getMetrics()
+            .flatMap((rm) => rm.scopeMetrics)
+            .flatMap((sm) => sm.metrics)
+            .find((m) => m.descriptor.name === name);
+    };
+
+    return {
+        async sums(name) {
+            const metric = (await find(name)) as SumMetricData | undefined;
+            return metric?.dataPoints.map((dp) => [dp.attributes, dp.value]) ?? [];
+        },
+        async histograms(name) {
+            const metric = (await find(name)) as HistogramMetricData | undefined;
+            return metric?.dataPoints.map((dp) => [dp.attributes, { count: dp.value.count, sum: dp.value.sum }]) ?? [];
+        },
+        async dispose() {
+            await provider.shutdown();
+            metrics.disable();
+            __resetMetricsForTest();
+        },
+    };
+}

--- a/harness/src/execution/reconcile-manifest.test.ts
+++ b/harness/src/execution/reconcile-manifest.test.ts
@@ -14,7 +14,7 @@ import { metrics } from "@opentelemetry/api";
 import { AggregationTemporality, InMemoryMetricExporter, MeterProvider, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 
 import { createCapturingLogger } from "../__tests__/setup/logger.js";
-import { __resetReconcileMetricsForTest } from "../lib/metrics.js";
+import { __resetMetricsForTest } from "../lib/metrics.js";
 import { ProvenanceCollector } from "../provenance/collector.js";
 import { feedExecFrame } from "../provenance/exec-frame.js";
 import { reconcileManifestWithDisk } from "./reconcile-manifest.js";
@@ -621,7 +621,7 @@ describe("reconcileManifestWithDisk — metric labels", () => {
             readers: [new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 3_600_000 })],
         });
         metrics.setGlobalMeterProvider(provider);
-        __resetReconcileMetricsForTest();
+        __resetMetricsForTest();
 
         // A phantom manifest entry (never written) drops one manifest entry, and
         // the absent upstream input drops one lineage input with reason `missing`.
@@ -652,7 +652,7 @@ describe("reconcileManifestWithDisk — metric labels", () => {
             await rm(sessionPath, { recursive: true, force: true });
             await provider.shutdown();
             metrics.disable();
-            __resetReconcileMetricsForTest();
+            __resetMetricsForTest();
         }
     });
 });

--- a/harness/src/execution/run-canceler.test.ts
+++ b/harness/src/execution/run-canceler.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from "bun:test";
 import type { Pool } from "pg";
 
+import { captureMetrics } from "../__tests__/setup/metrics.js";
 import type { AgentSession } from "../auth/types.js";
 import type { RunCharge } from "../billing/run-charge.js";
 import type { RunAuthorizer } from "./run-authorizer.js";
@@ -297,5 +298,35 @@ describe("createRunCanceler", () => {
         expect(db.state.run?.status).toBe("running");
         expect(db.state.swept).toBe(0);
         expect(closes).toEqual([]);
+    });
+});
+
+describe("createRunCanceler outcome metrics", () => {
+    it("a cancel that wins the row records the run canceled from its ledger start, and each cut child as a canceled step", async () => {
+        const capture = captureMetrics();
+        try {
+            // s1 was cut mid-flight; s2 wrote its own terminal row before the cancel; s3 never started.
+            const steps = [stepRow("s1", "wf-child-1"), stepRow("s2", "wf-child-2", "2026-08-12T00:30:00.000Z"), stepRow("s3", null)];
+            const db = fakeDb(runRow(), [steps]);
+            const { charge } = recordingCharge();
+            const { authorizer } = recordingAuthorizer();
+            const { cancelWorkflows } = recordingCancel();
+            const canceler = createRunCanceler({ pool: db.pool, runCharge: charge, runAuthorizer: authorizer, cancelWorkflows });
+
+            const result = await canceler.cancel("run-1", session);
+
+            expect(result.outcome).toBe("canceled");
+            expect(await capture.sums("cortex.run.completed")).toEqual([[{ status: "canceled", workflow: "analysis" }, 1]]);
+            const [duration] = await capture.histograms("cortex.run.duration_ms");
+            expect(duration?.[0]).toEqual({ status: "canceled", workflow: "analysis" });
+            expect(duration?.[1].count).toBe(1);
+            // Measured from the row's `started_at` (2026-08-12), so it is at least that far in the past.
+            expect(duration?.[1].sum).toBeGreaterThan(Date.now() - Date.parse("2026-08-13T00:00:00.000Z"));
+            // The cut child is counted without a duration; the child with a terminal row is left to itself.
+            expect(await capture.sums("cortex.step.completed")).toEqual([[{ status: "canceled", agent_id: "test-agent" }, 1]]);
+            expect(await capture.histograms("cortex.step.duration_ms")).toEqual([]);
+        } finally {
+            await capture.dispose();
+        }
     });
 });

--- a/harness/src/execution/run-canceler.ts
+++ b/harness/src/execution/run-canceler.ts
@@ -24,9 +24,10 @@ import type { AgentSession } from "../auth/types.js";
 import type { RunCharge } from "../billing/run-charge.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
+import { elapsedSinceIso, recordRunCompleted, recordStepCompleted } from "../lib/metrics.js";
 import { unwrapOrThrow } from "../lib/result.js";
 import { markRunCanceledIfActive, queryRun } from "../state/runs.js";
-import type { RunStatus } from "../state/schema.js";
+import type { RunStatus, StepExecutionRow } from "../state/schema.js";
 import { queryStepsByRun, sweepPendingStepExecutions } from "../state/step-executions.js";
 import { createDbosWorkflowPurger } from "./dbos-workflow-purger.js";
 import type { RunAuthorizer } from "./run-authorizer.js";
@@ -101,11 +102,10 @@ export function createRunCanceler(deps: RunCancelerDeps): RunCanceler {
         await engineCancel(workflowIds);
     };
 
-    /** Persisted child workflow ids of steps not yet completed. */
-    const incompleteChildIds = async (runId: string): Promise<string[]> =>
-        unwrapOrThrow(await queryStepsByRun(pool, runId)).flatMap((step) =>
-            step.childWorkflowId !== null && step.completedAt === null ? [step.childWorkflowId] : [],
-        );
+    /** Steps whose child started (a persisted child workflow id) and has not written its terminal row. */
+    const incompleteSteps = async (runId: string): Promise<StepExecutionRow[]> =>
+        unwrapOrThrow(await queryStepsByRun(pool, runId)).filter((step) => step.childWorkflowId !== null && step.completedAt === null);
+    const childIds = (steps: readonly StepExecutionRow[]): string[] => steps.flatMap((step) => (step.childWorkflowId !== null ? [step.childWorkflowId] : []));
 
     return {
         async cancel(runId, session) {
@@ -128,10 +128,14 @@ export function createRunCanceler(deps: RunCancelerDeps): RunCanceler {
             // mark-running step has not yet committed its child_workflow_id. The
             // persisted ids and the post-cancel re-query are belt-and-braces over
             // both ledgers' lag.
-            const knownChildren = await incompleteChildIds(runId);
+            const knownChildren = childIds(await incompleteSteps(runId));
             await cancelWorkflows([workflowId, ...knownChildren]);
+            // The steps the cancel cut: read after the cancel landed, so a child that
+            // wrote its terminal row in the meantime is not among them.
+            let cutSteps: StepExecutionRow[] | undefined;
             try {
-                const late = (await incompleteChildIds(runId)).filter((id) => !knownChildren.includes(id));
+                cutSteps = await incompleteSteps(runId);
+                const late = childIds(cutSteps).filter((id) => !knownChildren.includes(id));
                 if (late.length > 0) await cancelWorkflows(late);
             } catch (err) {
                 logger.error("late-child cancel sweep failed", { runId, ...logger.errorFields(err) });
@@ -143,6 +147,15 @@ export function createRunCanceler(deps: RunCancelerDeps): RunCanceler {
                 transitioned = unwrapOrThrow(await markRunCanceledIfActive(pool, runId, EXTERNAL_CANCEL_REASON));
             } catch (err) {
                 logger.error("markRunCanceledIfActive failed", { runId, ...logger.errorFields(err) });
+            }
+            // The workflow's own terminal step never runs after a cancel, so this
+            // conditional write is the one terminal write of an external cancel, and
+            // the outcome metrics ride behind it: a refused write means the run
+            // settled on its own and its own terminal step recorded them. A cut
+            // child never reached its terminal row, so its step records here too.
+            if (transitioned) {
+                recordRunCompleted({ workflow: "analysis", status: "canceled", durationMs: elapsedSinceIso(row.startedAt) });
+                for (const step of cutSteps ?? []) recordStepCompleted({ agentId: step.agentId, status: "canceled" });
             }
 
             let steps = false;

--- a/harness/src/lib/metrics.test.ts
+++ b/harness/src/lib/metrics.test.ts
@@ -9,14 +9,23 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { metrics } from "@opentelemetry/api";
 import { AggregationTemporality, InMemoryMetricExporter, MeterProvider, type MetricData, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 
+import { captureMetrics } from "../__tests__/setup/metrics.js";
 // Imported before any provider exists — the order the production barrel has.
-import { __resetReconcileMetricsForTest, recordArtifactReconcileDropped, recordLineageInputDropped } from "./metrics.js";
+import {
+    __resetMetricsForTest,
+    elapsedSinceIso,
+    recordArtifactReconcileDropped,
+    recordLineageInputDropped,
+    recordRunCompleted,
+    recordStepCompleted,
+    stepOutcomeOf,
+} from "./metrics.js";
 
 let exporter: InMemoryMetricExporter;
 let provider: MeterProvider;
 
 beforeEach(() => {
-    __resetReconcileMetricsForTest();
+    __resetMetricsForTest();
     exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
     provider = new MeterProvider({
         readers: [new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 3_600_000 })],
@@ -26,7 +35,7 @@ beforeEach(() => {
 afterEach(async () => {
     await provider.shutdown();
     metrics.disable();
-    __resetReconcileMetricsForTest();
+    __resetMetricsForTest();
 });
 
 async function collect(): Promise<MetricData[]> {
@@ -64,5 +73,41 @@ describe("reconcile metrics", () => {
             { agent_id: "agent-x", reason: "missing" },
             { agent_id: "agent-y", reason: "missing" },
         ]);
+    });
+});
+
+describe("run and step outcome metrics", () => {
+    it("a run and a step outcome each give one count and one duration sample under the bounded labels only", async () => {
+        await provider.shutdown();
+        const capture = captureMetrics();
+        try {
+            recordRunCompleted({ workflow: "analysis", status: "partial", durationMs: 900_000 });
+            // A blocked step is a failure to deliver; a step without a durable duration is counted, not timed.
+            recordStepCompleted({ agentId: "enrichment", status: stepOutcomeOf("blocked")!, durationMs: 3_000 });
+            recordStepCompleted({ agentId: "enrichment", status: "canceled" });
+
+            expect(await capture.sums("cortex.run.completed")).toEqual([[{ status: "partial", workflow: "analysis" }, 1]]);
+            expect(await capture.histograms("cortex.run.duration_ms")).toEqual([
+                [
+                    { status: "partial", workflow: "analysis" },
+                    { count: 1, sum: 900_000 },
+                ],
+            ]);
+            expect(await capture.sums("cortex.step.completed")).toEqual([
+                [{ status: "failed", agent_id: "enrichment" }, 1],
+                [{ status: "canceled", agent_id: "enrichment" }, 1],
+            ]);
+            expect(await capture.histograms("cortex.step.duration_ms")).toEqual([
+                [
+                    { status: "failed", agent_id: "enrichment" },
+                    { count: 1, sum: 3_000 },
+                ],
+            ]);
+            // A ledger with no start gives no duration; a skipped step gives no outcome.
+            expect(elapsedSinceIso(null)).toBeUndefined();
+            expect(stepOutcomeOf("skipped")).toBeUndefined();
+        } finally {
+            await capture.dispose();
+        }
     });
 });

--- a/harness/src/lib/metrics.ts
+++ b/harness/src/lib/metrics.ts
@@ -2,11 +2,22 @@
  * Custom OTel metrics for Cortex.
  *
  * Instruments:
- *   - cortex.artifact.reconcile.dropped — counter for missing manifest entries
- *   - cortex.artifact.reconcile.input_dropped — counter for lineage input drops
+ *   - cortex.run.completed{status, workflow}      — counter, one per run that reached a terminal status
+ *   - cortex.run.duration_ms{status, workflow}    — histogram, start to terminal status
+ *   - cortex.step.completed{status, agent_id}     — counter, one per executed step that settled
+ *   - cortex.step.duration_ms{status, agent_id}   — histogram, step start to its terminal ledger write
+ *   - cortex.artifact.reconcile.dropped{agent_id}              — counter for missing manifest entries
+ *   - cortex.artifact.reconcile.input_dropped{agent_id, reason} — counter for lineage input drops
  *
- * Both carry `agent_id` (about 15 values) and never a per-step or per-run
- * identifier: a label with unbounded values multiplies the series count.
+ * Every label is a bounded vocabulary: `status` is the terminal enum, `workflow`
+ * names the workflow family, `agent_id` has about 15 values. No instrument
+ * carries a run, step, exec, user, or organization id — a label with unbounded
+ * values multiplies the series count.
+ *
+ * A run or step outcome is recorded INSIDE the DBOS step that persists the same
+ * outcome to the ledger (or behind the ledger's own compare-and-set where the
+ * body has no such step). DBOS caches a completed step and does not re-run its
+ * body on recovery, so a replayed workflow records nothing twice.
  *
  * Instruments are lazy so the record site binds to whichever `MeterProvider`
  * is globally registered at first use. The metrics API has no late-binding
@@ -14,9 +25,31 @@
  * on the no-op provider for the life of the process.
  */
 
-import { type Counter, metrics } from "@opentelemetry/api";
+import { type Counter, type Histogram, metrics } from "@opentelemetry/api";
+
+import type { StepExecutionStatus } from "../state/schema.js";
+
+/** Terminal status of a run. A budget pause records as `canceled`, the same as the run ledger. */
+export type RunOutcome = "completed" | "partial" | "failed" | "canceled";
+
+/** The workflow family a run belongs to. */
+export type RunWorkflow = "analysis" | "target_assessment" | "data_profile";
+
+/** Terminal status of an executed step. A blocker is a failure to deliver, so `blocked` maps here to `failed`. */
+export type StepOutcome = "completed" | "failed" | "canceled";
+
+/**
+ * Bucket bounds for durations that run from seconds to hours: 30 s, then
+ * 1, 2, 5, 10, 30, 60, 120, 240 min. Ten buckets with the overflow, so one
+ * histogram costs about ten series per label set.
+ */
+export const RUN_DURATION_BOUNDS_MS: readonly number[] = [30_000, 60_000, 120_000, 300_000, 600_000, 1_800_000, 3_600_000, 7_200_000, 14_400_000];
 
 interface Instruments {
+    readonly runCompleted: Counter;
+    readonly runDuration: Histogram;
+    readonly stepCompleted: Counter;
+    readonly stepDuration: Histogram;
     readonly artifactReconcileDropped: Counter;
     readonly lineageInputDropped: Counter;
 }
@@ -26,7 +59,26 @@ let instruments: Instruments | undefined;
 function getInstruments(): Instruments {
     if (instruments === undefined) {
         const meter = metrics.getMeter("cortex");
+        const advice = { explicitBucketBoundaries: [...RUN_DURATION_BOUNDS_MS] };
         instruments = {
+            runCompleted: meter.createCounter("cortex.run.completed", {
+                description: "Runs that reached a terminal status. Tagged by status, workflow.",
+                unit: "{run}",
+            }),
+            runDuration: meter.createHistogram("cortex.run.duration_ms", {
+                description: "Run duration from its start to its terminal status. Tagged by status, workflow.",
+                unit: "ms",
+                advice,
+            }),
+            stepCompleted: meter.createCounter("cortex.step.completed", {
+                description: "Executed steps that settled. Tagged by status, agent_id.",
+                unit: "{step}",
+            }),
+            stepDuration: meter.createHistogram("cortex.step.duration_ms", {
+                description: "Step duration from its start to its terminal ledger write. Tagged by status, agent_id.",
+                unit: "ms",
+                advice,
+            }),
             artifactReconcileDropped: meter.createCounter("cortex.artifact.reconcile.dropped", {
                 description:
                     "Manifest entries dropped because their on-disk file was missing at " +
@@ -44,6 +96,69 @@ function getInstruments(): Instruments {
     return instruments;
 }
 
+/**
+ * Record one run that reached a terminal status. Call it inside the DBOS step
+ * that persists that status, or behind the ledger compare-and-set that accepted
+ * it. `durationMs` is omitted when the start instant is unknown: the run is
+ * then counted, not timed.
+ */
+export function recordRunCompleted(args: { readonly workflow: RunWorkflow; readonly status: RunOutcome; readonly durationMs?: number }): void {
+    const attributes = { status: args.status, workflow: args.workflow };
+    const { runCompleted, runDuration } = getInstruments();
+    runCompleted.add(1, attributes);
+    if (args.durationMs !== undefined) runDuration.record(Math.max(0, args.durationMs), attributes);
+}
+
+/**
+ * Record one executed step that settled. Call it inside the DBOS step that
+ * persists the terminal row, or inside the terminal step of the run for a
+ * step whose own body never reached one. `durationMs` is omitted when the
+ * step settled without a durable duration: it is then counted, not timed.
+ */
+export function recordStepCompleted(args: { readonly agentId: string; readonly status: StepOutcome; readonly durationMs?: number }): void {
+    const attributes = { status: args.status, agent_id: args.agentId };
+    const { stepCompleted, stepDuration } = getInstruments();
+    stepCompleted.add(1, attributes);
+    if (args.durationMs !== undefined) stepDuration.record(Math.max(0, args.durationMs), attributes);
+}
+
+/**
+ * The step outcome that a terminal ledger status records. A status that is not
+ * terminal (`pending`, `running`) or that names a step that never executed
+ * (`skipped`) records no outcome.
+ */
+export function stepOutcomeOf(status: StepExecutionStatus): StepOutcome | undefined {
+    switch (status) {
+        case "completed":
+            return "completed";
+        case "failed":
+        case "blocked":
+            return "failed";
+        case "canceled":
+            return "canceled";
+        case "pending":
+        case "running":
+        case "skipped":
+            return undefined;
+        default: {
+            const _exhaustive: never = status;
+            return _exhaustive;
+        }
+    }
+}
+
+/**
+ * Milliseconds from a persisted ISO-8601 start instant to `nowMs`. `undefined`
+ * when the ledger holds no start or an unparsable one, so the caller counts
+ * without a duration instead of recording a bogus one.
+ */
+export function elapsedSinceIso(startedAt: string | null | undefined, nowMs: number = Date.now()): number | undefined {
+    if (startedAt === null || startedAt === undefined) return undefined;
+    const startedMs = Date.parse(startedAt);
+    if (!Number.isFinite(startedMs)) return undefined;
+    return Math.max(0, nowMs - startedMs);
+}
+
 /** Record one manifest entry dropped at reconcile. */
 export function recordArtifactReconcileDropped(args: { readonly agentId: string }): void {
     getInstruments().artifactReconcileDropped.add(1, { agent_id: args.agentId });
@@ -57,6 +172,6 @@ export function recordLineageInputDropped(args: { readonly agentId: string; read
 }
 
 /** Test hook — drop memoised instruments to rebind a fresh MeterProvider. */
-export function __resetReconcileMetricsForTest(): void {
+export function __resetMetricsForTest(): void {
     instruments = undefined;
 }

--- a/harness/src/lib/otel.ts
+++ b/harness/src/lib/otel.ts
@@ -14,8 +14,12 @@
  *
  * Metrics: MeterProvider exports to OTLP when OTEL_EXPORTER_OTLP_ENDPOINT is
  *          set and OTEL_METRICS_EXPORTER is not `none`. The export interval is
- *          OTEL_METRIC_EXPORT_INTERVAL (ms), default 60 s. Custom Cortex
- *          metrics are defined in metrics.ts.
+ *          OTEL_METRIC_EXPORT_INTERVAL (ms), default 60 s. The run and step
+ *          outcome instruments (`cortex.run.*`, `cortex.step.*`) and the
+ *          reconcile counters are defined in metrics.ts; the agent loop, the
+ *          thread memory, and the workflows hold their own instruments next
+ *          to their record sites. Every instrument binds lazily to the
+ *          provider registered here.
  *
  * Resource: the host's `serviceName` / `serviceVersion` merged with the SDK
  *           env detector (`OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`);

--- a/harness/src/state/data-profile.test.ts
+++ b/harness/src/state/data-profile.test.ts
@@ -419,8 +419,8 @@ describe("terminal writes CAS on running — a cleared row is never resurrected"
     it("completeDataProfile no-ops after a clear and leaves the row cleared", async () => {
         await runningThenExpiredThenCleared("a-complete-after-clear");
 
-        const stamped = (await completeDataProfile(pool, "a-complete-after-clear", SAMPLE_RESULT))._unsafeUnwrap();
-        expect(stamped).toBe(false);
+        const write = (await completeDataProfile(pool, "a-complete-after-clear", SAMPLE_RESULT))._unsafeUnwrap();
+        expect(write).toEqual({ stamped: false });
 
         // Reads back as "no profile"; nothing resurrected — status, result, and seed all NULL.
         expect((await loadDataProfileStatus(pool, "a-complete-after-clear"))._unsafeUnwrap()).toBeNull();
@@ -436,8 +436,8 @@ describe("terminal writes CAS on running — a cleared row is never resurrected"
     it("failDataProfile no-ops after a clear and leaves the row cleared", async () => {
         await runningThenExpiredThenCleared("a-fail-after-clear");
 
-        const stamped = (await failDataProfile(pool, "a-fail-after-clear", "sandbox crashed"))._unsafeUnwrap();
-        expect(stamped).toBe(false);
+        const write = (await failDataProfile(pool, "a-fail-after-clear", "sandbox crashed"))._unsafeUnwrap();
+        expect(write).toEqual({ stamped: false });
 
         expect((await loadDataProfileStatus(pool, "a-fail-after-clear"))._unsafeUnwrap()).toBeNull();
         expect(await rawStatus(pool, "a-fail-after-clear")).toBeNull();
@@ -447,8 +447,10 @@ describe("terminal writes CAS on running — a cleared row is never resurrected"
         await seedAnalysis(pool, "a-complete-running", "pending");
         (await tryStartDataProfile(pool, "a-complete-running"))._unsafeUnwrap();
 
-        const stamped = (await completeDataProfile(pool, "a-complete-running", SAMPLE_RESULT))._unsafeUnwrap();
-        expect(stamped).toBe(true);
+        const write = (await completeDataProfile(pool, "a-complete-running", SAMPLE_RESULT))._unsafeUnwrap();
+        expect(write.stamped).toBe(true);
+        // The accepted stamp carries the start of the claim it closed.
+        expect(write.stamped && write.startedAt).toBe((await loadDataProfileStatus(pool, "a-complete-running"))._unsafeUnwrap()?.startedAt ?? null);
 
         const status = (await loadDataProfileStatus(pool, "a-complete-running"))._unsafeUnwrap();
         expect(status?.status).toBe("completed");
@@ -459,8 +461,9 @@ describe("terminal writes CAS on running — a cleared row is never resurrected"
         await seedAnalysis(pool, "a-fail-running", "pending");
         (await tryStartDataProfile(pool, "a-fail-running"))._unsafeUnwrap();
 
-        const stamped = (await failDataProfile(pool, "a-fail-running", "boom"))._unsafeUnwrap();
-        expect(stamped).toBe(true);
+        const write = (await failDataProfile(pool, "a-fail-running", "boom"))._unsafeUnwrap();
+        expect(write.stamped).toBe(true);
+        expect(write.stamped && write.startedAt).toBe((await loadDataProfileStatus(pool, "a-fail-running"))._unsafeUnwrap()?.startedAt ?? null);
 
         const status = (await loadDataProfileStatus(pool, "a-fail-running"))._unsafeUnwrap();
         expect(status?.status).toBe("failed");
@@ -547,7 +550,7 @@ describe("the persisted profile record", () => {
     it("a rich profile round-trips every field through the jsonb column", async () => {
         await seedAnalysis(pool, "a-rich", "pending");
         (await tryStartDataProfile(pool, "a-rich"))._unsafeUnwrap();
-        expect((await completeDataProfile(pool, "a-rich", RICH_RESULT))._unsafeUnwrap()).toBe(true);
+        expect((await completeDataProfile(pool, "a-rich", RICH_RESULT))._unsafeUnwrap().stamped).toBe(true);
 
         const status = (await loadDataProfileStatus(pool, "a-rich"))._unsafeUnwrap();
         expect(status?.status).toBe("completed");

--- a/harness/src/state/data-profile.ts
+++ b/harness/src/state/data-profile.ts
@@ -201,6 +201,19 @@ export function recordDataProfileWorkflowId(pool: Querier, analysisId: string, w
 }
 
 /**
+ * Outcome of a terminal compare-and-set on the profile row. The CAS accepts one
+ * write per `running` claim, so `stamped: true` is the exactly-once point of a
+ * profile's terminal transition. It carries the `data_profile_started_at` of the
+ * claim it closed, so the caller measures the profile from the ledger's own start.
+ */
+export type DataProfileTerminalWrite = { readonly stamped: false } | { readonly stamped: true; readonly startedAt: string | null };
+
+function terminalWriteOf(rows: ReadonlyArray<{ data_profile_started_at: string | null }>): DataProfileTerminalWrite {
+    const row = rows[0];
+    return row === undefined ? { stamped: false } : { stamped: true, startedAt: row.data_profile_started_at ?? null };
+}
+
+/**
  * Stamp a claimed-`running` row `completed` and record its result — a terminal
  * write CAS'd on `data_profile_status = 'running'`.
  *
@@ -215,20 +228,22 @@ export function recordDataProfileWorkflowId(pool: Querier, analysisId: string, w
  * Every legitimate caller reaches here from a row it claimed into `running`, so the
  * guard only ever refuses a row another writer already moved on from.
  *
- * `ok(true)` when this call stamped the row; `ok(false)` when the guard refused it
- * (the row was cleared/expired/replayed away) — a no-op the caller logs, not an error.
+ * `stamped: true` when this call stamped the row, with the `data_profile_started_at`
+ * of the claim it closed; `stamped: false` when the guard refused it (the row was
+ * cleared/expired/replayed away) — a no-op the caller logs, not an error.
  */
-export function completeDataProfile(pool: Querier, analysisId: string, result?: DataProfileResult): ResultAsync<boolean, DbError> {
+export function completeDataProfile(pool: Querier, analysisId: string, result?: DataProfileResult): ResultAsync<DataProfileTerminalWrite, DbError> {
     const now = new Date().toISOString();
     return tryMutation("dataProfile.completeDataProfile", async () => {
-        const res = await pool.query({
+        const res = await pool.query<{ data_profile_started_at: string | null }>({
             text: `UPDATE cortex_analysis_state
             SET data_profile_status = 'completed', data_profile_completed_at = $1,
                 data_profile_result = $2::jsonb
-            WHERE analysis_id = $3 AND data_profile_status = 'running'`,
+            WHERE analysis_id = $3 AND data_profile_status = 'running'
+            RETURNING data_profile_started_at`,
             values: [now, result ? JSON.stringify(result) : null, analysisId],
         });
-        return (res.rowCount ?? 0) > 0;
+        return terminalWriteOf(res.rows);
     });
 }
 
@@ -240,20 +255,22 @@ export function completeDataProfile(pool: Querier, analysisId: string, result?: 
  * `failed` status over a cleared row. `data_profile_result` is left untouched so a
  * prior profile survives the failure (the re-profile/retry route can keep serving it).
  *
- * `ok(true)` when this call stamped the row; `ok(false)` when the guard refused it —
- * a logged no-op, not an error.
+ * `stamped: true` when this call stamped the row, with the `data_profile_started_at`
+ * of the claim it closed; `stamped: false` when the guard refused it — a logged
+ * no-op, not an error.
  */
-export function failDataProfile(pool: Querier, analysisId: string, error: string): ResultAsync<boolean, DbError> {
+export function failDataProfile(pool: Querier, analysisId: string, error: string): ResultAsync<DataProfileTerminalWrite, DbError> {
     const now = new Date().toISOString();
     return tryMutation("dataProfile.failDataProfile", async () => {
-        const res = await pool.query({
+        const res = await pool.query<{ data_profile_started_at: string | null }>({
             text: `UPDATE cortex_analysis_state
             SET data_profile_status = 'failed', data_profile_error = $1,
                 data_profile_completed_at = $2
-            WHERE analysis_id = $3 AND data_profile_status = 'running'`,
+            WHERE analysis_id = $3 AND data_profile_status = 'running'
+            RETURNING data_profile_started_at`,
             values: [error, now, analysisId],
         });
-        return (res.rowCount ?? 0) > 0;
+        return terminalWriteOf(res.rows);
     });
 }
 

--- a/harness/src/state/index.ts
+++ b/harness/src/state/index.ts
@@ -69,6 +69,7 @@ export {
 } from "./data-profile.js";
 export type {
     DataProfileStatus,
+    DataProfileTerminalWrite,
     DataProfileResult,
     DataProfileChecked,
     DataProfileCompanionCompleteness,

--- a/harness/src/tasks/data-profile.ts
+++ b/harness/src/tasks/data-profile.ts
@@ -74,7 +74,9 @@ import {
     tryStartDataProfile,
     upsertArtifacts,
     type DataProfileResult,
+    type DataProfileTerminalWrite,
 } from "../state/index.js";
+import { elapsedSinceIso, recordRunCompleted } from "../lib/metrics.js";
 import { createProfileActivityEmitter, type ProfileActivityEmitter } from "./data-profile-activity.js";
 import { ensureSearchIndex, searchIndexName } from "../workspace/search-config.js";
 // The run literal is declared in `contracts/` — a consumer reads it back off recorded usage, and this
@@ -487,7 +489,7 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
             // catalogue's fit is measured, and a completion that emitted none would make the
             // empty-manifest path invisible to the same monitoring that watches every other.
             logProfileMonitoring(logger, { dimensions: [], probes: [], repairRounds: 0, absorb: "none" });
-            if (!unwrapOrThrow(await completeDataProfile(deps.pool, analysisId))) logTerminalNoop(logger, analysisId, "completion");
+            settleTerminalWrite(logger, analysisId, unwrapOrThrow(await completeDataProfile(deps.pool, analysisId)), "completed");
             await deps.runAuthorizer.revoke(authorization, "data-profile-completed");
             // This is a terminal completion like any other, so it reports one — a consumer watching
             // an empty-manifest profile sees it settle rather than seeing the stream simply stop.
@@ -547,7 +549,7 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
             await activity.indexing();
             await indexProfile({ deps, analysisId, session: runSession, record, scan, logger });
             logProfileMonitoring(logger, { resolution, dimensions: [], probes: [], repairRounds: 0, absorb: "none" });
-            if (!unwrapOrThrow(await completeDataProfile(deps.pool, analysisId, record))) logTerminalNoop(logger, analysisId, "completion");
+            settleTerminalWrite(logger, analysisId, unwrapOrThrow(await completeDataProfile(deps.pool, analysisId, record)), "completed");
             await deps.runAuthorizer.revoke(authorization, "data-profile-completed");
             await activity.complete();
             return;
@@ -574,7 +576,7 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
                 repairRounds: 0,
                 absorb: absorb.kind,
             });
-            if (!unwrapOrThrow(await completeDataProfile(deps.pool, analysisId, absorbed))) logTerminalNoop(logger, analysisId, "completion");
+            settleTerminalWrite(logger, analysisId, unwrapOrThrow(await completeDataProfile(deps.pool, analysisId, absorbed)), "completed");
             await deps.runAuthorizer.revoke(authorization, "data-profile-completed");
             await activity.complete();
             return;
@@ -785,9 +787,7 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
 
             // 6. Complete — store the FULL profiler finding plus the input signature for
             // staleness detection. The scratch tree is gone; this row is all that survives.
-            if (!unwrapOrThrow(await completeDataProfile(deps.pool, analysisId, profileRecord))) {
-                logTerminalNoop(logger, analysisId, "completion");
-            }
+            settleTerminalWrite(logger, analysisId, unwrapOrThrow(await completeDataProfile(deps.pool, analysisId, profileRecord)), "completed");
             await deps.runAuthorizer.revoke(authorization, "data-profile-completed");
             // LAST statement of the success path, and that placement is the guarantee that exactly
             // one terminal activity is ever emitted. Everything that could still throw — the ledger
@@ -806,7 +806,7 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
     } catch (err) {
         logger.error("profile failed", logger.errorFields(err));
         const reason = profileFailureReason(err);
-        if (!unwrapOrThrow(await failDataProfile(deps.pool, analysisId, reason))) logTerminalNoop(logger, analysisId, "failure");
+        settleTerminalWrite(logger, analysisId, unwrapOrThrow(await failDataProfile(deps.pool, analysisId, reason)), "failed");
         await deps.runAuthorizer.revoke(authorization, "data-profile-failed");
         // The same bounded, user-safe line the ledger receives — never the raw error, whose paths and
         // stack frames stay in the log record above. This is the only other terminal emission, so
@@ -823,6 +823,22 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
  */
 function logTerminalNoop(logger: Logger, analysisId: string, write: string): void {
     logger.warn("terminal write skipped: ledger row not running (cleared or expired concurrently)", { analysisId, write });
+}
+
+/**
+ * Settle one terminal write of the profile ledger. A refused stamp is logged
+ * (see `logTerminalNoop`). An accepted stamp records the profile's run outcome:
+ * the CAS admits one write per `running` claim, so this is the exactly-once
+ * point of the transition — a recovery replay of the body finds the row no
+ * longer `running`, and records nothing again. The duration runs from the
+ * `data_profile_started_at` the claim stamped, never from a body-local clock.
+ */
+function settleTerminalWrite(logger: Logger, analysisId: string, write: DataProfileTerminalWrite, status: "completed" | "failed"): void {
+    if (!write.stamped) {
+        logTerminalNoop(logger, analysisId, status === "completed" ? "completion" : "failure");
+        return;
+    }
+    recordRunCompleted({ workflow: "data_profile", status, durationMs: elapsedSinceIso(write.startedAt) });
 }
 
 /**
@@ -1010,12 +1026,15 @@ async function compensateStartFailure(deps: DataProfileTriggerDeps, analysisId: 
     const failed = await failDataProfile(deps.pool, analysisId, profileFailureReason(err));
     if (failed.isErr()) {
         logger.error("failed to mark failed after a start error", { phase, err: failed.error });
-    } else if (!failed.value) {
+    } else if (!failed.value.stamped) {
         // The row this compensation was written to fail is no longer `running` — a
         // concurrent clear/expire already moved it on, so the running-CAS refused the
         // stamp. Nothing wedged at `running`, which is the outcome compensation exists
         // to guarantee; just record the no-op.
         logTerminalNoop(logger, analysisId, "compensation");
+    } else {
+        // A profile that failed at start is a failed profile: its claim opened a run the ledger now closes.
+        recordRunCompleted({ workflow: "data_profile", status: "failed", durationMs: elapsedSinceIso(failed.value.startedAt) });
     }
 }
 

--- a/harness/src/workflows/__tests__/dbos/workflow-replay.test.ts
+++ b/harness/src/workflows/__tests__/dbos/workflow-replay.test.ts
@@ -52,6 +52,8 @@ import { DBOS } from "@dbos-inc/dbos-sdk";
 
 import { setupDbosForTests, type DbosTestRig } from "../../../__tests__/setup/dbos.js";
 import { silentLogger } from "../../../__tests__/setup/logger.js";
+import { captureMetrics } from "../../../__tests__/setup/metrics.js";
+import { recordRunCompleted, recordStepCompleted } from "../../../lib/metrics.js";
 
 // Reopen the registration window if an earlier test file already launched
 // the shared DBOS engine (see "Registration window" above).
@@ -165,6 +167,33 @@ const threeStepMirror = DBOS.registerWorkflow(
         return { a, b, c };
     },
     { name: "three-step-mirror" },
+);
+
+// ── Outcome metrics recorded inside the terminal step ───────────────────
+
+let terminalStepCalls = 0;
+
+/**
+ * Mirror of the placement rule of `lib/metrics.ts`: an outcome metric is
+ * recorded INSIDE the DBOS step that persists the terminal status. The
+ * unconditional self-cancel after it forces a replay through `resumeWorkflow`;
+ * the cached step returns without running its closure, so each counter reads one.
+ */
+const terminalMetricMirror = DBOS.registerWorkflow(
+    async (): Promise<{ terminalCalls: number }> => {
+        await DBOS.runStep(
+            async () => {
+                terminalStepCalls += 1;
+                recordStepCompleted({ agentId: "mirror-agent", status: "completed", durationMs: 1_500 });
+                recordRunCompleted({ workflow: "analysis", status: "completed", durationMs: 30_000 });
+            },
+            { name: "persist-final-status" },
+        );
+        await DBOS.cancelWorkflow(DBOS.workflowID!);
+        await DBOS.runStep(async () => undefined, { name: "post-terminal.tail" });
+        return { terminalCalls: terminalStepCalls };
+    },
+    { name: "terminal-metric-mirror" },
 );
 
 // ── 10.13 — sync attempted after a registration rejection ───────────────
@@ -461,5 +490,39 @@ describe("Integration test 10.13 — per-step sync (registration rejection + ide
 
         const status2 = await DBOS.getWorkflowStatus(wfId);
         expect(status2?.status).toBe("SUCCESS");
+    });
+});
+
+describe("run and step outcome metrics across a DBOS replay", () => {
+    it("a recovered workflow records each outcome once: the terminal step is cached, its closure never re-runs", async () => {
+        const capture = captureMetrics();
+        try {
+            terminalStepCalls = 0;
+            const wfId = rig.nextWorkflowId("metric-replay-");
+            const handle1 = await DBOS.startWorkflow(terminalMetricMirror, { workflowID: wfId })();
+            handle1.getResult().catch(() => {});
+            expect((await waitForTerminal(wfId))?.status).toBe("CANCELLED");
+
+            const result = await (await DBOS.resumeWorkflow<{ terminalCalls: number }>(wfId)).getResult();
+
+            // The body ran twice; the terminal step's closure ran once, and so did each record in it.
+            expect(result.terminalCalls).toBe(1);
+            expect(await capture.sums("cortex.run.completed")).toEqual([[{ status: "completed", workflow: "analysis" }, 1]]);
+            expect(await capture.histograms("cortex.run.duration_ms")).toEqual([
+                [
+                    { status: "completed", workflow: "analysis" },
+                    { count: 1, sum: 30_000 },
+                ],
+            ]);
+            expect(await capture.sums("cortex.step.completed")).toEqual([[{ status: "completed", agent_id: "mirror-agent" }, 1]]);
+            expect(await capture.histograms("cortex.step.duration_ms")).toEqual([
+                [
+                    { status: "completed", agent_id: "mirror-agent" },
+                    { count: 1, sum: 1_500 },
+                ],
+            ]);
+        } finally {
+            await capture.dispose();
+        }
     });
 });

--- a/harness/src/workflows/execute-analysis.test.ts
+++ b/harness/src/workflows/execute-analysis.test.ts
@@ -41,6 +41,7 @@ import type { SandboxStepInput, SandboxStepResult } from "./sandbox-step.js";
 import type { ChatProvider, EmbeddingProvider } from "../providers/types.js";
 import type { AnalysisStep } from "../schemas/workflow-state.js";
 import { unusedCitationResolver } from "../citations/__fixtures__/resolver.js";
+import { captureMetrics } from "../__tests__/setup/metrics.js";
 
 // ── Fake DBOS surface ────────────────────────────────────────────────
 
@@ -1729,5 +1730,55 @@ describe("executeAnalysis run observation", () => {
         const once = fold(seen);
         const twice = fold([...seen, ...seen]);
         expect(twice).toEqual(once!);
+    });
+});
+
+// ── Run and step outcome metrics at the terminal step ────────────────
+
+describe("run and step outcome metrics", () => {
+    /** One `cortex_step_executions` row, cut down to the columns `queryStepsByRun` maps and the residue rule reads. */
+    const ledgerRow = (stepId: string, completedAt: string | null, status = completedAt === null ? "running" : "completed"): Record<string, unknown> => ({
+        run_id: "run-test",
+        step_id: stepId,
+        analysis_id: "a1",
+        wave: 0,
+        agent_id: "agent-x",
+        status,
+        completed_at: completedAt,
+        child_workflow_id: status === "pending" ? null : `run-test-${stepId}`,
+    });
+
+    // The one branch of `persist-final-status` a replay test cannot reach: which settled steps the
+    // parent counts. A child that wrote its terminal row (completed_at set) already recorded itself.
+    it("persist-final-status counts the run once, and only the settled steps whose child wrote no terminal row", async () => {
+        const capture = captureMetrics();
+        try {
+            // A completed and wrote its row. B failed and C was cancelled before either child reached its
+            // terminal step, so their rows carry no completed_at. D never dispatched.
+            const pool = makeFakePool({
+                SELECT: [ledgerRow("A", "2026-09-05T10:05:00.000Z"), ledgerRow("B", null), ledgerRow("C", null), ledgerRow("D", null, "pending")],
+            });
+            const { deps } = makeDeps({
+                pool,
+                childResults: new Map<string, SandboxStepResult | Error>([
+                    ["A", { status: "complete", durationMs: 5, finishReason: "stop", error: null }],
+                    ["B", new Error("sandbox create failed")],
+                    ["C", { status: "canceled", durationMs: 3, finishReason: null, error: null }],
+                ]),
+            });
+
+            const result = await runExecuteAnalysisBody(input([{ id: "A" }, { id: "B" }, { id: "C" }, { id: "D", depends_on: ["B"] }]), deps);
+
+            expect(result.status).toBe("partial");
+            expect(await capture.sums("cortex.run.completed")).toEqual([[{ status: "partial", workflow: "analysis" }, 1]]);
+            expect(await capture.sums("cortex.step.completed")).toEqual([
+                [{ status: "failed", agent_id: "agent-x" }, 1],
+                [{ status: "canceled", agent_id: "agent-x" }, 1],
+            ]);
+            // A residual step settled without a durable duration: counted, not timed.
+            expect(await capture.histograms("cortex.step.duration_ms")).toEqual([]);
+        } finally {
+            await capture.dispose();
+        }
     });
 });

--- a/harness/src/workflows/execute-analysis.ts
+++ b/harness/src/workflows/execute-analysis.ts
@@ -51,7 +51,10 @@
  *  5. `synthesizeFindings` (single sequential block, no sandbox)
  *  6. `collectAndComplete` (terminal — runs on ALL paths)
  *     - determine final status from completed/cancelled/failed counts
- *     - update `cortex_runs.status` + `error`
+ *     - update `cortex_runs.status` + `error`, and inside that same step record
+ *       the run outcome metric plus the outcome of every settled step whose
+ *       child never wrote its own terminal row (a cancelled child, or one that
+ *       died before `failStep`)
  *     - close running charge with matching reason
  *     - revoke run authorization via the injected `runAuthorizer` seam
  *     - emit terminal stream part
@@ -71,6 +74,7 @@ import type { RunAuthorization, RunAuthorizer } from "../execution/run-authorize
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
 import { ATTR_INFLEXA_STEP_ID, stableSpan } from "../lib/otel-spans.js";
+import { recordRunCompleted, recordStepCompleted, stepOutcomeOf } from "../lib/metrics.js";
 import type { UsageRecorder } from "../billing/usage-recorder.js";
 import type { CitationResolver } from "../citations/types.js";
 import { unwrapOrThrow } from "../lib/result.js";
@@ -81,6 +85,7 @@ import {
     loadDataProfileStatus,
     queryActiveRun,
     queryStepArtifactPaths,
+    queryStepsByRun,
     seedStepExecutions,
     setRunSynthesisOutcome,
     suspendAnalysis as suspendAnalysisQuery,
@@ -88,7 +93,7 @@ import {
     updateRunStatus,
     updateStepExecution,
 } from "../state/index.js";
-import type { SynthesisStatus, UpdateStepExecutionInput } from "../state/index.js";
+import type { StepExecutionRow, SynthesisStatus, UpdateStepExecutionInput } from "../state/index.js";
 import { isBudgetExceeded } from "../loop/budget-exceeded.js";
 import { addChatUsage, hasReportedUsage, type AgentRunUsage } from "../loop/metrics.js";
 import type { TokenUsageRollup } from "../contracts/usage.js";
@@ -837,11 +842,14 @@ export async function runExecuteAnalysisBody(input: ExecuteAnalysisInput, deps: 
         const rowOutcome = synthesisOutcome;
         try {
             const synthEndedAtMs = await DBOS.now();
+            const rowUpdate = synthesisRowUpdate(rowOutcome, synthEndedAtMs - synthStartedAtMs);
             await DBOS.runStep(
                 async () => {
-                    unwrapOrThrow(
-                        await updateStepExecution(deps.pool, runId, SYNTHESIS_STEP_ID, synthesisRowUpdate(rowOutcome, synthEndedAtMs - synthStartedAtMs)),
-                    );
+                    unwrapOrThrow(await updateStepExecution(deps.pool, runId, SYNTHESIS_STEP_ID, rowUpdate));
+                    // Recorded inside the step that writes the row, so a replayed body records nothing again.
+                    const outcome = stepOutcomeOf(rowUpdate.status);
+                    if (outcome !== undefined)
+                        recordStepCompleted({ agentId: SYNTHESIS_AGENT_ID, status: outcome, durationMs: synthEndedAtMs - synthStartedAtMs });
                 },
                 { name: "persist-synthesis-step" },
             );
@@ -1447,6 +1455,24 @@ async function collectAndComplete(args: CollectAndCompleteArgs): Promise<Execute
                 unwrapOrThrow(
                     await updateRunStatus(deps.pool, runId, status, failureReason ?? (status === "canceled" && !budgetExceeded ? "external_cancel" : null)),
                 );
+                // The outcome metrics ride inside the step that persists the terminal status: DBOS
+                // caches the step, so a recovered body records nothing again. A step's own terminal
+                // row already carried its metric; the residue counted here is every settled step
+                // without one — a child the cancel cut before `mark-canceled` (the cancel check runs
+                // before a step body), or one that died before `failStep`. The ledger read is kept
+                // apart from the status write: a failed read costs the metrics, never the write.
+                let stepRows: readonly StepExecutionRow[] = [];
+                try {
+                    stepRows = unwrapOrThrow(await queryStepsByRun(deps.pool, runId));
+                } catch (err) {
+                    logger.warn("run metrics: step ledger read failed, residual step outcomes skipped", logger.errorFields(err));
+                }
+                for (const row of stepRows) {
+                    if (row.completedAt !== null) continue;
+                    if (canceled.has(row.stepId)) recordStepCompleted({ agentId: row.agentId, status: "canceled" });
+                    else if (failed.has(row.stepId)) recordStepCompleted({ agentId: row.agentId, status: "failed" });
+                }
+                recordRunCompleted({ workflow: "analysis", status, durationMs: terminalAtMs - startedAtMs });
             },
             { name: "persist-final-status" },
         );

--- a/harness/src/workflows/execute-target-assessment.ts
+++ b/harness/src/workflows/execute-target-assessment.ts
@@ -84,6 +84,7 @@ import { readBudgetExceededMarker } from "./target-assessment/lib/llm-step.js";
 import { assembleSafetyCorroboration } from "./target-assessment/lib/safety-corroboration.js";
 import { investigateClaims, isClaimInvestigationBudgetExceeded, type ClaimInvestigationConfig } from "./target-assessment/investigation/index.js";
 import { recordTerminalReason } from "./target-assessment/metrics.js";
+import { elapsedSinceIso, recordRunCompleted } from "../lib/metrics.js";
 import { phase4Assemble } from "./target-assessment/phase4-assemble.js";
 import { DossierDerivedInvariantError, DossierSchemaViolationError, phase5Persist } from "./target-assessment/phase5-persist.js";
 import { emitProgress, type ProgressPhase } from "./target-assessment/progress.js";
@@ -638,9 +639,23 @@ export async function runExecuteTargetAssessmentBody(
 
     // (§6.1, §6.8) Terminal block. Read the row first; if soft-deleted,
     // no-op (the user's delete during the run wins).
-    const row = await DBOS.runStep(async () => unwrapOrThrow(await getAssessment(deps.pool, input.assessmentId, input.organizationId)), {
-        name: "ta-terminal-read-row",
-    });
+    //
+    // Each terminal path records its `cortex.run.completed` outcome INSIDE the
+    // DBOS step that persists it, so a recovery replay reads the cached step
+    // and records nothing again. The duration runs from the row's `created_at`.
+    // The deleted path writes no row, so its record rides the read step itself.
+    const row = await DBOS.runStep(
+        async () => {
+            const read = unwrapOrThrow(await getAssessment(deps.pool, input.assessmentId, input.organizationId));
+            if (read?.status === "deleted") {
+                recordRunCompleted({ workflow: "target_assessment", status: "canceled", durationMs: elapsedSinceIso(read.createdAt) });
+            }
+            return read;
+        },
+        { name: "ta-terminal-read-row" },
+    );
+    const recordTerminal = (status: "completed" | "failed" | "canceled"): void =>
+        recordRunCompleted({ workflow: "target_assessment", status, durationMs: elapsedSinceIso(row?.createdAt) });
     if (row?.status === "deleted") {
         recordTerminalReason("deleted");
         return {
@@ -653,9 +668,13 @@ export async function runExecuteTargetAssessmentBody(
     // (§6.2) Normal completion — happy path wrote `dossierForPersist`.
     if (!phase0Error && !schemaViolation && !derivedViolation && !unexpectedError && !budgetExceeded && dossierForPersist) {
         try {
-            await DBOS.runStep(async () => unwrapOrThrow(await setDossier(deps.pool, input.assessmentId, dossierForPersist!)), {
-                name: "ta-terminal-completed",
-            });
+            await DBOS.runStep(
+                async () => {
+                    unwrapOrThrow(await setDossier(deps.pool, input.assessmentId, dossierForPersist!));
+                    recordTerminal("completed");
+                },
+                { name: "ta-terminal-completed" },
+            );
             await emitProgress(deps.pool, logger, input.assessmentId, "completed");
         } catch (err) {
             logger.named("ta-terminal").error("setDossier failed", logger.errorFields(err));
@@ -672,13 +691,15 @@ export async function runExecuteTargetAssessmentBody(
     // (§6.3) Phase 0 throw — target unresolved.
     if (phase0Error) {
         await DBOS.runStep(
-            async () =>
+            async () => {
                 unwrapOrThrow(
                     await markFailed(deps.pool, input.assessmentId, {
                         kind: "target-unresolved",
                         message: phase0Error instanceof Error ? phase0Error.message : String(phase0Error),
                     }),
-                ),
+                );
+                recordTerminal("failed");
+            },
             { name: "ta-terminal-failed-resolve" },
         );
         await emitProgress(deps.pool, logger, input.assessmentId, "failed");
@@ -694,14 +715,16 @@ export async function runExecuteTargetAssessmentBody(
     // (§6.4) Schema violation.
     if (schemaViolation) {
         await DBOS.runStep(
-            async () =>
+            async () => {
                 unwrapOrThrow(
                     await markFailed(deps.pool, input.assessmentId, {
                         kind: "schema-invariant-violation",
                         message: schemaViolation!.message,
                         details: schemaViolation!.issues,
                     }),
-                ),
+                );
+                recordTerminal("failed");
+            },
             { name: "ta-terminal-failed-schema" },
         );
         await emitProgress(deps.pool, logger, input.assessmentId, "failed");
@@ -717,13 +740,15 @@ export async function runExecuteTargetAssessmentBody(
     // (§6.4 — derived invariant variant — same terminal class, different kind.)
     if (derivedViolation) {
         await DBOS.runStep(
-            async () =>
+            async () => {
                 unwrapOrThrow(
                     await markFailed(deps.pool, input.assessmentId, {
                         kind: "derived-invariant-violation",
                         message: derivedViolation!.message,
                     }),
-                ),
+                );
+                recordTerminal("failed");
+            },
             { name: "ta-terminal-failed-derived" },
         );
         await emitProgress(deps.pool, logger, input.assessmentId, "failed");
@@ -745,7 +770,14 @@ export async function runExecuteTargetAssessmentBody(
         await DBOS.runStep(() => readBudgetExceededMarker(), {
             name: "ta-terminal-drain-marker",
         }).catch(() => null);
-        await DBOS.runStep(async () => unwrapOrThrow(await markAssessmentSuspended(deps.pool, input.assessmentId)), { name: "ta-terminal-suspended" });
+        await DBOS.runStep(
+            async () => {
+                unwrapOrThrow(await markAssessmentSuspended(deps.pool, input.assessmentId));
+                // A budget pause records as `canceled`, the same status the analysis run ledger gives it.
+                recordTerminal("canceled");
+            },
+            { name: "ta-terminal-suspended" },
+        );
         await emitProgress(deps.pool, logger, input.assessmentId, "suspended");
         await revokeRunAuthorizationSafe(deps, authorization, "target-assessment-canceled");
         const workflowId = DBOS.workflowID;
@@ -770,13 +802,15 @@ export async function runExecuteTargetAssessmentBody(
     // (§6.5) Unexpected throw — bug somewhere, coverage envelope failed.
     if (unexpectedError) {
         await DBOS.runStep(
-            async () =>
+            async () => {
                 unwrapOrThrow(
                     await markFailed(deps.pool, input.assessmentId, {
                         kind: "unexpected-throw",
                         message: unexpectedError instanceof Error ? unexpectedError.message : String(unexpectedError),
                     }),
-                ),
+                );
+                recordTerminal("failed");
+            },
             { name: "ta-terminal-failed-unexpected" },
         );
         await emitProgress(deps.pool, logger, input.assessmentId, "failed");
@@ -793,13 +827,15 @@ export async function runExecuteTargetAssessmentBody(
     // categories above must have fired). Fall through to a generic failed
     // status so a buggy refactor surfaces visibly.
     await DBOS.runStep(
-        async () =>
+        async () => {
             unwrapOrThrow(
                 await markFailed(deps.pool, input.assessmentId, {
                     kind: "unexpected-throw",
                     message: "terminal block reached without classified outcome",
                 }),
-            ),
+            );
+            recordTerminal("failed");
+        },
         { name: "ta-terminal-failed-uncategorized" },
     );
     recordTerminalReason("unexpected-throw");

--- a/harness/src/workflows/sandbox-step.ts
+++ b/harness/src/workflows/sandbox-step.ts
@@ -33,6 +33,7 @@ import type { TokenUsageRollup } from "@inflexa-ai/harness/contracts/usage.js";
 import type { Pool } from "pg";
 
 import { insertStepExecution, updateStepExecution } from "../state/index.js";
+import { recordStepCompleted } from "../lib/metrics.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
 import type { UsageRecorder } from "../billing/usage-recorder.js";
@@ -582,6 +583,7 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
                         lastErrorClass: errorClass,
                     }),
                 );
+                recordStepCompleted({ agentId: input.agentId, status: "failed", durationMs });
             },
             {
                 name: errorClass === "lineage_attestation" ? "mark-failed-attestation" : "mark-failed",
@@ -790,6 +792,7 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
                         hitMaxSteps,
                     }),
                 );
+                recordStepCompleted({ agentId: input.agentId, status: "failed", durationMs });
             },
             { name: "mark-blocked" },
         );
@@ -919,7 +922,9 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
     // (9) teardown — destroy sandbox + clear sandbox_ref.
     await DBOS.runStep(() => deps.sandboxClient.teardown(sandbox), { name: "sandbox.teardown" });
 
-    // (10) mark-terminal + emit.
+    // (10) mark-terminal + emit. The outcome metric is recorded inside the same
+    // step as the ledger row: a replayed body reads the cached step and records
+    // nothing again.
     const durationMs = (await DBOS.now()) - startedAt;
     await DBOS.runStep(
         async () => {
@@ -933,6 +938,7 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
                     hitMaxSteps,
                 }),
             );
+            recordStepCompleted({ agentId: input.agentId, status: "completed", durationMs });
         },
         { name: "mark-complete" },
     );


### PR DESCRIPTION
## What & why

The harness owns the runs and the steps, so it records their outcome metrics. Four instruments live in `harness/src/lib/metrics.ts` on the lazy meter, next to the reconcile counters.

| Instrument | Labels | Vocabulary |
| --- | --- | --- |
| `cortex.run.completed` (counter) | `status`, `workflow` | `status` ∈ completed, partial, failed, canceled. `workflow` ∈ analysis, target_assessment, data_profile |
| `cortex.run.duration_ms` (histogram) | `status`, `workflow` | the same, bounds 30 s to 4 h |
| `cortex.step.completed` (counter) | `status`, `agent_id` | `status` ∈ completed, failed, canceled. `agent_id` is the sandbox agent, about 15 values |
| `cortex.step.duration_ms` (histogram) | `status`, `agent_id` | the same, bounds 30 s to 4 h |

No instrument carries a run, step, exec, user, or organization id. A blocked step records as `failed`, and a budget pause records as `canceled`, the same as the ledgers. A skipped step records nothing, because it never ran.

Notes for the reviewer:

- **Placement makes the replay safe.** Each record sits inside the DBOS step that persists the same outcome. DBOS caches a completed step and does not run its body again on recovery, so a replayed workflow records nothing twice. The sites: `persist-final-status` and `persist-synthesis-step` in `execute-analysis.ts`, `mark-complete`, `mark-blocked`, `mark-failed`, and `mark-failed-attestation` in `sandbox-step.ts`, and the `ta-terminal-*` steps in `execute-target-assessment.ts`. A test in `workflow-replay.test.ts` resumes a cancelled workflow through the real engine and reads a count of one.
- **A cancelled child never reaches its terminal step.** DBOS checks the cancel before it runs a step body (`dbos-executor.js:476`), so `mark-canceled` and the record in it never execute. The parent counts such a step inside `persist-final-status`, from the ledger rows that carry no `completed_at`. The same rule counts a child that died before `failStep`. The comment above `mark-canceled` in `sandbox-step.ts` says that the step flips the row. It does not, and this PR does not change that code.
- **An external cancel** never reaches `collectAndComplete`. The run and its cut children record behind `markRunCanceledIfActive` in `run-canceler.ts`, a conditional write that accepts one transition.
- **The data-profile body has no terminal step.** Its terminal compare-and-set accepts one write per `running` claim. `completeDataProfile` and `failDataProfile` now return `{ stamped, startedAt }` instead of a boolean, and the body records only on an accepted stamp. The compensation of a failed start records `failed` the same way.
- **The label is `status`.** The observability plan (`02-signal-catalog.md` P1, `03-checklist.md` B3) names it `status`, so the dashboards keep the name.
- **Durations come from persisted instants.** The run and step bodies subtract two checkpointed `DBOS.now()` reads, the same span that the provenance events and `duration_ms` carry. The target assessment, the run canceler, and the data profile read `created_at` or `started_at` from their ledgers. A duration that cannot be measured is omitted, and the outcome is counted, not timed.
- **Not counted:** `extract-values` and `derive-table-exec`. They have no ledger row and no DBOS step, so the only replay-safe site would be a step made for the metric. `expireStaleDataProfile` and `reconcileOrphanedDataProfile` close a profile from outside its workflow and are not counted either.
- The version bump to 0.35.4 is a separate commit.

Gates: `tsc --noEmit` clean. `eslint .` reports one error in `src/providers/ai-sdk.test.ts:1378` that is present on `main`. `bun run test:full` 4317 pass, 0 fail, 18 skip.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

https://claude.ai/code/session_01XJ3U53ivPT6zGc5FL7N4vv
