### PR TITLE
fix(ci): guard the disk of the builder before each build

### DIFF
--- a/.github/workflows/package-store-build.yml
+++ b/.github/workflows/package-store-build.yml
@@ -5,6 +5,10 @@ name: Build the package store
 # one artifact per architecture, through an ORAS push.
 #
 # The sequence per arch, from the package-store-build spec:
+#   0. disk guard — before any build on a self-hosted builder,
+#      scripts/package-store-disk-guard.sh reclaims what no run owns (stale
+#      store volumes, unused images, the build cache above a cap) and fails
+#      the job in seconds when the Docker data root lacks the headroom.
 #   1. resolve — `provision build` resolves the manifest, with the committed
 #      per-arch lock second (the `npm install` model), and builds the catalog
 #      farm. The updated lock files commit back with a signed-off commit.
@@ -145,6 +149,16 @@ jobs:
         # The store streams out of the volume and compresses with zstd. The
         # runner user has no sudo on the self-hosted builders, so fail loudly.
         run: command -v zstd >/dev/null || { echo "::error::zstd not found on the builder"; exit 1; }
+
+      - name: Disk guard
+        # Docker's data root is a persistent volume, and nothing else on the
+        # box reclaims it. The guard removes what no run owns, prunes the
+        # build cache to a cap, and measures the filesystem. A store build
+        # needs about 40 GB at its peak: the store volume, the two images,
+        # and the provisioner's caches and source builds. 60 keeps a margin.
+        env:
+          NEED_GB: "60"
+        run: scripts/package-store-disk-guard.sh
 
       - name: Prove the python of the coverage gate
         # The coverage step imports yaml AFTER the multi-hour build. A missing
@@ -637,6 +651,9 @@ jobs:
         run: |
           docker rmi "${PROVISIONER_IMAGE}:${VERSION}-${ARCH}" 2>/dev/null || true
           docker rmi "${SANDBOX_IMAGE}:${VERSION}-${ARCH}" 2>/dev/null || true
+          # A canceled check leaves its container on the volume, and the
+          # volume cannot go before the container does.
+          docker ps -aq --filter "volume=${STORE_VOLUME}" | xargs -r docker rm -f 2>/dev/null || true
           docker volume rm "$STORE_VOLUME" 2>/dev/null || true
           rm -rf dist lockout load-check.json r-base-loaded.txt current-lock.json
           docker image prune -f 2>/dev/null || true

--- a/.github/workflows/sandbox-images-build.yml
+++ b/.github/workflows/sandbox-images-build.yml
@@ -111,6 +111,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      - name: Disk guard
+        # The two image builds need the base image, their layers, and the
+        # build cache that keeps the next build fast. 30 GB covers that.
+        env:
+          NEED_GB: "30"
+        run: scripts/package-store-disk-guard.sh
+
       - name: Set up Docker Buildx
         # Use the docker daemon's built-in builder (not a docker-container builder):
         # its BuildKit cache lives in /var/lib/docker — the persistent EBS volume —

--- a/docs/local-package-store.md
+++ b/docs/local-package-store.md
@@ -243,6 +243,13 @@ packages: six workers against a 300-second timeout for 3.5 hours.
     built. The base and recommended packages of R count as loaded when the
     sandbox image loads them, and an R name compares across the three
     subtrees.
+40. The disk guard runs before each build on a self-hosted builder. It
+    removes the containers and the store volumes that no run owns, and every
+    unused image. It prunes the build cache to a cap, and then it measures
+    the free space of the Docker data root. A box below the headroom fails
+    the job in seconds. On 2026-09-05 the amd64 box held 155 GB of retired
+    images, stale cache, and one leaked volume, and the build died on
+    ENOSPC.
 
 ### The image-hygiene decisions (round 12, 2026-08-20)
 

--- a/harness/openspec/specs/package-store-build/spec.md
+++ b/harness/openspec/specs/package-store-build/spec.md
@@ -263,6 +263,30 @@ library path and form one dependency chain.
 - **WHEN** the workflow completes
 - **THEN** the amd64 artifact publishes, and the arm64 failure reports
 
+### Requirement: A build starts with the headroom it needs
+
+Each build job on a self-hosted builder MUST run the disk guard before it
+builds an image or a store. Docker writes to a persistent volume there, and no
+process outside the workflows reclaims it. The guard MUST remove the containers
+that no run owns, the store volumes of other runs, and every image that
+nothing uses. It MUST prune the build cache to a cap, with the least recently
+used entries first. Then it MUST measure the free space of the filesystem of
+the Docker data root, not the tally of Docker. If the free space is below the
+headroom of the job, the job MUST fail at once, and the message MUST give the
+numbers.
+
+#### Scenario: A stale volume of a canceled run
+
+- **GIVEN** a builder that holds the store volume of a canceled run
+- **WHEN** the guard runs
+- **THEN** the volume is gone before the build starts
+
+#### Scenario: A box without headroom fails fast
+
+- **GIVEN** a builder with less free space than the job needs after the reclaim
+- **WHEN** the guard runs
+- **THEN** the job fails in seconds, and the message names the free space and the need
+
 ### Requirement: The github track installs through pak, with the token present
 
 A build whose manifest names a `github` entry MUST refuse to start when

--- a/scripts/package-store-disk-guard.sh
+++ b/scripts/package-store-disk-guard.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# The disk guard of the self-hosted builders.
+#
+# Docker's data root sits on a persistent volume that survives every run, and
+# no process outside the workflows reclaims it. The workflows remove their own
+# objects at the end of a run, but three things escape that: a canceled run
+# keeps its store volume, because the cleanup meets a container that still
+# holds the volume; a retired image tag stays forever, because `docker image
+# prune` without `-a` removes dangling images only; and the BuildKit cache
+# grows with every image build, because nothing prunes it. On 2026-09-05 the
+# amd64 box held 155 GB of such content on a 196 GB volume, and the store
+# build died on ENOSPC in the R github stage, hours in.
+#
+# The guard runs before a build. It removes what no run owns, prunes the build
+# cache to a cap, then measures the FILESYSTEM of the data root: overlay
+# leftovers count on disk and in no row of `docker system df`. A box below the
+# headroom fails the job here, in seconds, with the numbers.
+#
+# Usage: package-store-disk-guard.sh [<volume to keep>]
+#   NEED_GB     the free space the job needs, in GB (default 60)
+#   KEEP_CACHE  the build cache to keep; the least recently used entries go
+#               first (default 25GB)
+set -euo pipefail
+
+keep_volume="${1:-}"
+need_gb="${NEED_GB:-60}"
+keep_cache="${KEEP_CACHE:-25GB}"
+
+root="$(docker info --format '{{.DockerRootDir}}')"
+free_gb() { df -BG --output=avail "$root" | tail -n 1 | tr -dc '0-9'; }
+
+before="$(free_gb)"
+
+docker container prune -f >/dev/null
+
+# The `name` filter matches a substring, thus every run's store volume answers.
+for volume in $(docker volume ls -q --filter 'name=package-store-'); do
+  if [ "$volume" = "$keep_volume" ]; then continue; fi
+  # A container of a canceled run can still hold the volume; the volume
+  # cannot go before that container does.
+  docker ps -aq --filter "volume=$volume" | xargs -r docker rm -f >/dev/null
+  if docker volume rm "$volume" >/dev/null; then
+    echo "disk guard: removed the stale volume $volume"
+  fi
+done
+
+# Every image that nothing uses. A run pulls or builds its own images, thus a
+# cached tag saves nothing that the build cache below does not save better.
+docker image prune -a -f >/dev/null
+docker builder prune -f --keep-storage "$keep_cache" >/dev/null
+
+after="$(free_gb)"
+echo "disk guard: ${root} had ${before} GB free, has ${after} GB free after the reclaim, and the job needs ${need_gb} GB"
+if [ "$after" -lt "$need_gb" ]; then
+  echo "::error::the builder has ${after} GB free on ${root}, and the job needs ${need_gb} GB; inspect with: docker system df; du -sh ${root}/*"
+  exit 1
+fi


### PR DESCRIPTION
The Package Store Pipeline of 2026-09-05 died on ENOSPC in the R github stage of the amd64 build. Docker on the builder writes to a persistent 196 GB volume. Content that no run owned held 155 GB of it. The content was 80 GB of retired image tags, 52 GB of BuildKit cache, and one leaked store volume. The workflows remove only their own objects, and `docker image prune -f` removes dangling images only. The guard that the infrastructure comment names never existed on the box.

The disk guard runs first in each build job. It removes the containers and the store volumes that no run owns, and every unused image. It prunes the build cache to a cap, and then it measures the free space of the Docker data root. A job that lacks its headroom fails in seconds, with the numbers. The cleanup step now removes the container that holds the store volume before the volume, because a canceled check leaves that container behind.