### PR TITLE
harness: name the duration histograms without the unit

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.35.4",
+    "version": "0.35.5",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/execution/run-canceler.test.ts
+++ b/harness/src/execution/run-canceler.test.ts
@@ -317,14 +317,14 @@ describe("createRunCanceler outcome metrics", () => {
 
             expect(result.outcome).toBe("canceled");
             expect(await capture.sums("cortex.run.completed")).toEqual([[{ status: "canceled", workflow: "analysis" }, 1]]);
-            const [duration] = await capture.histograms("cortex.run.duration_ms");
+            const [duration] = await capture.histograms("cortex.run.duration");
             expect(duration?.[0]).toEqual({ status: "canceled", workflow: "analysis" });
             expect(duration?.[1].count).toBe(1);
             // Measured from the row's `started_at` (2026-08-12), so it is at least that far in the past.
             expect(duration?.[1].sum).toBeGreaterThan(Date.now() - Date.parse("2026-08-13T00:00:00.000Z"));
             // The cut child is counted without a duration; the child with a terminal row is left to itself.
             expect(await capture.sums("cortex.step.completed")).toEqual([[{ status: "canceled", agent_id: "test-agent" }, 1]]);
-            expect(await capture.histograms("cortex.step.duration_ms")).toEqual([]);
+            expect(await capture.histograms("cortex.step.duration")).toEqual([]);
         } finally {
             await capture.dispose();
         }

--- a/harness/src/lib/metrics.test.ts
+++ b/harness/src/lib/metrics.test.ts
@@ -87,7 +87,7 @@ describe("run and step outcome metrics", () => {
             recordStepCompleted({ agentId: "enrichment", status: "canceled" });
 
             expect(await capture.sums("cortex.run.completed")).toEqual([[{ status: "partial", workflow: "analysis" }, 1]]);
-            expect(await capture.histograms("cortex.run.duration_ms")).toEqual([
+            expect(await capture.histograms("cortex.run.duration")).toEqual([
                 [
                     { status: "partial", workflow: "analysis" },
                     { count: 1, sum: 900_000 },
@@ -97,7 +97,7 @@ describe("run and step outcome metrics", () => {
                 [{ status: "failed", agent_id: "enrichment" }, 1],
                 [{ status: "canceled", agent_id: "enrichment" }, 1],
             ]);
-            expect(await capture.histograms("cortex.step.duration_ms")).toEqual([
+            expect(await capture.histograms("cortex.step.duration")).toEqual([
                 [
                     { status: "failed", agent_id: "enrichment" },
                     { count: 1, sum: 3_000 },

--- a/harness/src/lib/metrics.ts
+++ b/harness/src/lib/metrics.ts
@@ -3,9 +3,9 @@
  *
  * Instruments:
  *   - cortex.run.completed{status, workflow}      — counter, one per run that reached a terminal status
- *   - cortex.run.duration_ms{status, workflow}    — histogram, start to terminal status
+ *   - cortex.run.duration{status, workflow}       — histogram, start to terminal status
  *   - cortex.step.completed{status, agent_id}     — counter, one per executed step that settled
- *   - cortex.step.duration_ms{status, agent_id}   — histogram, step start to its terminal ledger write
+ *   - cortex.step.duration{status, agent_id}      — histogram, step start to its terminal ledger write
  *   - cortex.artifact.reconcile.dropped{agent_id}              — counter for missing manifest entries
  *   - cortex.artifact.reconcile.input_dropped{agent_id, reason} — counter for lineage input drops
  *
@@ -65,7 +65,7 @@ function getInstruments(): Instruments {
                 description: "Runs that reached a terminal status. Tagged by status, workflow.",
                 unit: "{run}",
             }),
-            runDuration: meter.createHistogram("cortex.run.duration_ms", {
+            runDuration: meter.createHistogram("cortex.run.duration", {
                 description: "Run duration from its start to its terminal status. Tagged by status, workflow.",
                 unit: "ms",
                 advice,
@@ -74,7 +74,7 @@ function getInstruments(): Instruments {
                 description: "Executed steps that settled. Tagged by status, agent_id.",
                 unit: "{step}",
             }),
-            stepDuration: meter.createHistogram("cortex.step.duration_ms", {
+            stepDuration: meter.createHistogram("cortex.step.duration", {
                 description: "Step duration from its start to its terminal ledger write. Tagged by status, agent_id.",
                 unit: "ms",
                 advice,

--- a/harness/src/workflows/__tests__/dbos/workflow-replay.test.ts
+++ b/harness/src/workflows/__tests__/dbos/workflow-replay.test.ts
@@ -508,14 +508,14 @@ describe("run and step outcome metrics across a DBOS replay", () => {
             // The body ran twice; the terminal step's closure ran once, and so did each record in it.
             expect(result.terminalCalls).toBe(1);
             expect(await capture.sums("cortex.run.completed")).toEqual([[{ status: "completed", workflow: "analysis" }, 1]]);
-            expect(await capture.histograms("cortex.run.duration_ms")).toEqual([
+            expect(await capture.histograms("cortex.run.duration")).toEqual([
                 [
                     { status: "completed", workflow: "analysis" },
                     { count: 1, sum: 30_000 },
                 ],
             ]);
             expect(await capture.sums("cortex.step.completed")).toEqual([[{ status: "completed", agent_id: "mirror-agent" }, 1]]);
-            expect(await capture.histograms("cortex.step.duration_ms")).toEqual([
+            expect(await capture.histograms("cortex.step.duration")).toEqual([
                 [
                     { status: "completed", agent_id: "mirror-agent" },
                     { count: 1, sum: 1_500 },

--- a/harness/src/workflows/execute-analysis.test.ts
+++ b/harness/src/workflows/execute-analysis.test.ts
@@ -1776,7 +1776,7 @@ describe("run and step outcome metrics", () => {
                 [{ status: "canceled", agent_id: "agent-x" }, 1],
             ]);
             // A residual step settled without a durable duration: counted, not timed.
-            expect(await capture.histograms("cortex.step.duration_ms")).toEqual([]);
+            expect(await capture.histograms("cortex.step.duration")).toEqual([]);
         } finally {
             await capture.dispose();
         }


### PR DESCRIPTION
## What & why

The OpenTelemetry Prometheus exporter and the Grafana Cloud OTLP ingest add the unit to the name of a metric. The run and step duration histograms export as `cortex_run_duration_ms_milliseconds_{bucket,sum,count}` and `cortex_step_duration_ms_milliseconds_{bucket,sum,count}`. The OTel naming rule: the name does not contain the unit, and the `unit` field gives the unit. The exporter then adds the unit one time.

The two histograms are now `cortex.run.duration` and `cortex.step.duration`. The unit stays `ms`, and the bucket bounds stay the same. They export as `cortex_run_duration_milliseconds_*` and `cortex_step_duration_milliseconds_*`.

Notes for the reviewer:

- No other harness instrument has a unit in its name. The token, turn, and iteration instruments carry an annotation unit (`{token}`, `{turn}`, `{iteration}`), and the exporter does not add an annotation to the name.
- The version bump to 0.35.5 is a separate commit.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

https://claude.ai/code/session_01XJ3U53ivPT6zGc5FL7N4vv
