### PR TITLE
feat(harness): add the UniProt protein search tool

### DIFF
--- a/harness/openspec/specs/uniprot-tools/spec.md
+++ b/harness/openspec/specs/uniprot-tools/spec.md
@@ -1,0 +1,149 @@
+# uniprot-tools Specification
+
+## Purpose
+
+Defines the harness tool `search_protein`, which wraps the UniProtKB search
+endpoint (`https://rest.uniprot.org/uniprotkb/search`). UniProtKB is the curated
+protein knowledgebase of EMBL-EBI, SIB, and PIR. It is keyless and public.
+
+`harness/src/tools/lib/uniprot-client.ts` held `getUniProtRecord` before this
+tool, but only the target-assessment workflow imported it. Thus no agent could
+look up a protein. `search_gene` accepts a UniProt accession, but it answers
+with Ensembl gene records only. This tool answers with the protein itself: the
+name, the gene names, the sequence length, the curated function, and the
+subcellular locations.
+
+The tool follows the harness tool-error contract literally. The search endpoint
+answers an unknown query with HTTP 200 and `{"results":[]}`, and never with a
+404. Thus the empty answer is `ok({ proteins: [] })` and it needs no
+status-code branch. An unexpected failure throws out of `execute` — a 5xx, a
+timeout, retry exhaustion, or a schema mismatch. The agent loop then wraps it
+as a `tool_result { is_error: true }`.
+
+Three decisions bind the tool. First, the search takes its own field list.
+`FIELDS` feeds `getUniProtRecord` and the target-assessment dossier, thus a
+widening of it would change what that workflow reads.
+
+Second, the query shape comes from the input. An input that matches a
+documented UniProt accession form is looked up as `accession:`, and every other
+input as `gene_exact:`. Thus one input field serves both identifier spaces, and
+a caller never states which one it holds.
+
+Third, the answer is bounded and it says so. UniProt reports its match count in
+the `x-total-results` header, and `apiFetch` exposes no header. Thus the client
+asks for one row beyond the limit and reports `hasMore`. That separates a
+trimmed answer from a complete one, which is what the bio barrel requires.
+
+## Requirements
+
+### Requirement: UniProtKB protein search tool
+
+The system MUST give a `searchProteinTool` (on-wire id `search_protein`, built
+with `defineTool`) that takes a required `query` string. It MUST also take
+`organismId` (an NCBI Taxonomy ID, default 9606, nullable to search every
+organism), `reviewedOnly` (default true), and `limit`. It MUST return
+`ok({ proteins, hasMore })`. Each protein carries `accession`, `uniProtkbId`,
+`proteinName`, `geneNames`, `sequenceLength`, `function`,
+`subcellularLocations`, and `reviewed`.
+
+#### Scenario: A gene symbol resolves to its reviewed protein
+
+- **WHEN** the tool is called with `query: "BRCA1"` and the default organism and reviewed filter
+- **THEN** it returns one protein whose `accession` is `P38398` and whose `uniProtkbId` is `BRCA1_HUMAN`
+
+#### Scenario: An accession is looked up as an accession
+
+- **WHEN** the `query` matches a documented UniProt accession form, for example `P38398` or `A0A0B4J1Y9`
+- **THEN** the request carries an `accession:` clause, and not a `gene_exact:` clause
+
+#### Scenario: A symbol is looked up as a gene symbol
+
+- **WHEN** the `query` matches no accession form, for example `BRCA1`
+- **THEN** the request carries a `gene_exact:` clause
+
+#### Scenario: An unknown query returns an empty array
+
+- **WHEN** UniProt answers HTTP 200 with `{"results":[]}`
+- **THEN** the tool returns `ok({ proteins: [], hasMore: false })`, and not an `is_error` tool result
+
+#### Scenario: The reviewed filter is a toggle
+
+- **WHEN** `reviewedOnly` is false
+- **THEN** the request carries no `reviewed:true` clause, thus a TrEMBL entry can answer
+
+#### Scenario: Every organism is reachable
+
+- **WHEN** `organismId` is null
+- **THEN** the request carries no `organism_id:` clause
+
+#### Scenario: A trimmed answer says that it was trimmed
+
+- **WHEN** UniProt holds more rows than `limit`
+- **THEN** the tool returns `limit` proteins and `hasMore: true`
+
+#### Scenario: A server error surfaces as an error tool result
+
+- **WHEN** UniProt returns a 5xx after retries are exhausted
+- **THEN** `execute` throws, and the agent loop records the call as `tool_result { is_error: true }`
+
+### Requirement: describeCall names the query
+
+The tool MUST declare a `describeCall` hook that returns the `query` verbatim.
+Thus a caller tells one call from another by the query alone.
+
+#### Scenario: describeCall reports the query
+
+- **WHEN** `describeCall` is invoked with `{ query: "BRCA1" }`
+- **THEN** it returns the string `"BRCA1"`
+
+### Requirement: The search client obeys the absence policy of UniProt
+
+`searchProteins` MUST live in `harness/src/tools/lib/uniprot-client.ts`, beside
+`getUniProtRecord`. It MUST take its own field list, and it MUST NOT widen the
+`FIELDS` constant. Each field of the search schema MUST carry `.optional()`,
+because UniProt omits the key of an absent value and never sends null. The
+schema MUST be exported, so that the golden-fixture table drives it.
+
+#### Scenario: An entry that omits the optional keys still maps
+
+- **WHEN** a result row omits `genes` and `comments`, as `Q6ZQY7` does
+- **THEN** the mapped protein carries empty `geneNames`, a null `function`, and empty `subcellularLocations`
+
+#### Scenario: A submitted name stands in for a recommended name
+
+- **WHEN** a TrEMBL row carries `submissionNames` and no `recommendedName`, as `X5D778` does
+- **THEN** `proteinName` reads the submitted name, and it is not null
+
+#### Scenario: A repeated location is kept once
+
+- **WHEN** UniProt splits the subcellular locations over more than one comment and repeats one of them
+- **THEN** `subcellularLocations` holds each distinct location one time, in the order UniProt lists them
+
+### Requirement: search_protein reaches the conversation agent and the literature reviewer
+
+The tool MUST be wired into the conversation agent
+(`harness/src/agents/conversation-agent.ts`) and into the literature reviewer
+(`harness/src/tools/research/literature-reviewer.ts`). The prompt of the
+literature reviewer names each tool that it holds, thus
+`harness/src/prompts/literature-reviewer.ts` MUST carry a usage note for this
+one.
+
+The tool MUST NOT be an entry in the sandbox tool registry, and
+`SandboxToolName` (`harness/src/agents/sandbox/types.ts`) MUST NOT name it.
+Identifier resolution answers a question of the conversation, thus no sandbox
+agent reaches for one yet.
+
+#### Scenario: Conversation agent has the tool
+
+- **WHEN** the conversation agent is created
+- **THEN** its tool array includes `searchProteinTool`
+
+#### Scenario: The literature reviewer has the tool and its prompt says so
+
+- **WHEN** the literature reviewer tool is built
+- **THEN** its tool array includes `searchProteinTool`, and its prompt names `search_protein` in the tool usage notes
+
+#### Scenario: No sandbox agent can declare the tool
+
+- **WHEN** a sandbox-agent meta names the tool in `meta.tools`
+- **THEN** the name is not a `SandboxToolName`, thus the typecheck rejects it

--- a/harness/openspec/specs/uniprot-tools/spec.md
+++ b/harness/openspec/specs/uniprot-tools/spec.md
@@ -24,10 +24,18 @@ Three decisions bind the tool. First, the search takes its own field list.
 `FIELDS` feeds `getUniProtRecord` and the target-assessment dossier, thus a
 widening of it would change what that workflow reads.
 
-Second, the query shape comes from the input. An input that matches a
-documented UniProt accession form is looked up as `accession:`, and every other
-input as `gene_exact:`. Thus one input field serves both identifier spaces, and
-a caller never states which one it holds.
+Second, the two identifier spaces overlap, thus the query searches both. A
+gene symbol such as `P2RY12` or `B3GAT1` matches the accession form exactly. A
+lookup in the accession space alone reports that protein as absent. Thus an
+accession-shaped input searches both spaces.
+
+The shape still decides one thing. UniProt validates the value of an
+`accession:` clause, and it answers HTTP 400 for a value that is not
+accession-shaped. Thus a plain symbol never reaches that clause.
+
+The narrowing filters stay off the accession side. An accession is a unique
+key, and `accession:P02769` under the human default would otherwise answer
+nothing, although that accession names bovine serum albumin.
 
 Third, the answer is bounded and it says so. UniProt reports its match count in
 the `x-total-results` header, and `apiFetch` exposes no header. Thus the client
@@ -51,15 +59,20 @@ organism), `reviewedOnly` (default true), and `limit`. It MUST return
 - **WHEN** the tool is called with `query: "BRCA1"` and the default organism and reviewed filter
 - **THEN** it returns one protein whose `accession` is `P38398` and whose `uniProtkbId` is `BRCA1_HUMAN`
 
-#### Scenario: An accession is looked up as an accession
+#### Scenario: An accession-shaped input searches both identifier spaces
 
-- **WHEN** the `query` matches a documented UniProt accession form, for example `P38398` or `A0A0B4J1Y9`
-- **THEN** the request carries an `accession:` clause, and not a `gene_exact:` clause
+- **WHEN** the `query` matches a documented UniProt accession form, for example `P38398`, `A0A0B4J1Y9`, or the gene symbol `P2RY12`
+- **THEN** the request OR-s an `accession:` clause with the `gene_exact:` clause, thus a symbol that is shaped like an accession still resolves
 
-#### Scenario: A symbol is looked up as a gene symbol
+#### Scenario: The narrowing filters stay off the accession clause
+
+- **WHEN** the `query` is an accession that names an entry of another organism, for example `P02769` under the default `organismId` of 9606
+- **THEN** the `organism_id:` and `reviewed:true` clauses bind the `gene_exact:` side only, and the accession still resolves
+
+#### Scenario: A symbol that is not accession-shaped sends no accession clause
 
 - **WHEN** the `query` matches no accession form, for example `BRCA1`
-- **THEN** the request carries a `gene_exact:` clause
+- **THEN** the request carries a `gene_exact:` clause and no `accession:` clause, because UniProt answers HTTP 400 for an accession value it cannot parse
 
 #### Scenario: An unknown query returns an empty array
 
@@ -113,6 +126,16 @@ schema MUST be exported, so that the golden-fixture table drives it.
 
 - **WHEN** a TrEMBL row carries `submissionNames` and no `recommendedName`, as `X5D778` does
 - **THEN** `proteinName` reads the submitted name, and it is not null
+
+#### Scenario: A TrEMBL row reports reviewed false
+
+- **WHEN** `entryType` reads `UniProtKB unreviewed (TrEMBL)`
+- **THEN** `reviewed` is false, because the client matches `unreviewed` before it matches `reviewed`
+
+#### Scenario: A Swiss-Prot row reports reviewed true
+
+- **WHEN** `entryType` reads `UniProtKB reviewed (Swiss-Prot)`
+- **THEN** `reviewed` is true
 
 #### Scenario: A repeated location is kept once
 

--- a/harness/openspec/specs/uniprot-tools/spec.md
+++ b/harness/openspec/specs/uniprot-tools/spec.md
@@ -37,6 +37,12 @@ The narrowing filters stay off the accession side. An accession is a unique
 key, and `accession:P02769` under the human default would otherwise answer
 nothing, although that accession names bovine serum albumin.
 
+The accession side carries `active:true`, and that is the one filter it takes.
+A deleted accession still answers an `accession:` query, as an `Inactive` row
+with no name and no function, and the mapper has no field for the deletion
+reason. `B3GAT1` names one such accession. Thus the filter removes that hollow
+row from the answer.
+
 Third, the answer is bounded and it says so. UniProt reports its match count in
 the `x-total-results` header, and `apiFetch` exposes no header. Thus the client
 asks for one row beyond the limit and reports `hasMore`. That separates a
@@ -68,6 +74,11 @@ organism), `reviewedOnly` (default true), and `limit`. It MUST return
 
 - **WHEN** the `query` is an accession that names an entry of another organism, for example `P02769` under the default `organismId` of 9606
 - **THEN** the `organism_id:` and `reviewed:true` clauses bind the `gene_exact:` side only, and the accession still resolves
+
+#### Scenario: A deleted accession does not answer
+
+- **WHEN** the `query` is accession-shaped and it also names a deleted entry, for example `B3GAT1`
+- **THEN** the `accession:` clause carries `active:true`, thus the `Inactive` row does not answer, and the `gene_exact:` side still resolves the human protein
 
 #### Scenario: A symbol that is not accession-shaped sends no accession clause
 

--- a/harness/src/agents/conversation-agent.ts
+++ b/harness/src/agents/conversation-agent.ts
@@ -44,6 +44,7 @@ import { composeSystemPrompt } from "./system-prompt.js";
 // Bio-lookup leaf tools (pure — no dependencies).
 import {
     searchGeneTool,
+    searchProteinTool,
     lookupAnnotationTool,
     searchInteractionsTool,
     alphafoldPredictionTool,
@@ -238,8 +239,10 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
     });
 
     const tools: Tool[] = [
-        // Identifier resolution — the ENSG most other bio tools key off.
+        // Identifier resolution — the ENSG most other bio tools key off, and the
+        // UniProt accession that the structure tools take.
         searchGeneTool,
+        searchProteinTool,
         // Functional annotation (GO / KEGG / Reactome behind one vocabulary) and
         // STRING networks + gene-set enrichment.
         lookupAnnotationTool,

--- a/harness/src/prompts/literature-reviewer.ts
+++ b/harness/src/prompts/literature-reviewer.ts
@@ -21,6 +21,10 @@ turn and forces a retry.
   list. Shape: \`{ identifiers: ["TP53", "BRCA1", ...], limit: 50 }\`.
 - \`search_gene\` — batches up to 200 symbols; \`lookup_annotation\` takes one
   term or accession per call.
+- \`search_protein\` — one gene symbol or UniProt accession per call. It answers
+  with the protein: the accession, the recommended name, the sequence length,
+  the curated function, and the subcellular locations. An empty \`proteins\`
+  array is a valid "no data" outcome; do NOT retry the same call.
 - \`gene_preclinical_profile\` — single human gene symbol per call; returns
   baseline expression and mouse-KO phenotype together. Empty/null fields are
   valid "no data" outcomes (Bgee may have no calls for dog or macaque; many
@@ -36,21 +40,25 @@ that silently drops the other 200.
 
 For each gene, pathway, or feature in the brief:
 
-1. **Gene/protein lookup** — use \`search_gene\` to get function, aliases,
-   associated diseases, and expression patterns.
-2. **Pathway context** — use \`lookup_annotation({vocabulary:"pathways"})\` to
+1. **Gene lookup** — use \`search_gene\` to get the gene: its Ensembl ID,
+   coordinates, biotype, and aliases.
+2. **Protein lookup** — use \`search_protein\` when the claim is about the
+   protein rather than the locus: what it does, how long it is, and where in
+   the cell it acts. It also returns the UniProt accession, which is the key
+   the structure tools take.
+3. **Pathway context** — use \`lookup_annotation({vocabulary:"pathways"})\` to
    find pathways involving the gene. Note which pathways connect multiple
    genes from the brief.
-3. **GO terms** — use \`lookup_annotation({vocabulary:"go"})\` for functional
+4. **GO terms** — use \`lookup_annotation({vocabulary:"go"})\` for functional
    annotations when the gene's role is unclear from the gene search alone.
-4. **Protein interactions** — use \`search_interactions\` to find
+5. **Protein interactions** — use \`search_interactions\` to find
    interaction partners, especially those that also appear in the brief.
-5. **Literature evidence** — use \`pubmed({action:"search"})\` with targeted queries
+6. **Literature evidence** — use \`pubmed({action:"search"})\` with targeted queries
    combining the gene name with the disease/condition from the brief.
    Use \`pubmed({action:"details"})\` for the most relevant hits. Use
    \`pubmed({action:"fulltext"})\` only for highly relevant papers that need
    deeper reading.
-6. **Preclinical grounding** — when the brief asks about tissue expression,
+7. **Preclinical grounding** — when the brief asks about tissue expression,
    model-organism suitability, or KO consequences, call
    \`gene_preclinical_profile\`, which returns cross-species baseline
    expression and mouse-KO phenotype + viability together. It takes a single
@@ -59,7 +67,7 @@ For each gene, pathway, or feature in the brief:
 ## Depth Guidelines
 
 - **Top priority targets** (top DE genes, hub genes, user-specified):
-  Full investigation — all 5 steps above.
+  Full investigation — every step above.
 - **Supporting targets** (enriched pathways, interaction partners):
   Gene lookup + pathway + literature. Skip GO terms and interactions
   unless results are ambiguous.

--- a/harness/src/tools/bio/index.ts
+++ b/harness/src/tools/bio/index.ts
@@ -22,6 +22,7 @@
 
 // Identifier resolution
 export * from "./search-gene.js";
+export * from "./search-protein.js";
 
 // Functional annotation / networks
 export * from "./lookup-annotation.js";

--- a/harness/src/tools/bio/search-protein.test.ts
+++ b/harness/src/tools/bio/search-protein.test.ts
@@ -66,12 +66,38 @@ describe("searchProtein — a resolved symbol", () => {
         expect(sentQuery()).toBe("gene_exact:BRCA1 AND organism_id:9606 AND reviewed:true");
     });
 
-    it("queries accession for an input shaped like one", async () => {
+    // A symbol that is not accession-shaped must never reach an `accession:`
+    // clause, because UniProt validates that value and answers HTTP 400 for one
+    // it cannot parse, which fails the whole request.
+    it("sends no accession clause for an input that is not accession-shaped", async () => {
         stubResponse(200, readFixture("uniprot", "search_BRCA1_reviewed.json"));
 
-        await callSearchProtein({ query: "P38398" });
+        await callSearchProtein({ query: "BRCA1" });
 
-        expect(sentQuery()).toBe("accession:P38398 AND organism_id:9606 AND reviewed:true");
+        expect(sentQuery()).not.toContain("accession:");
+    });
+
+    // The two identifier spaces overlap: `P2RY12` is a real gene symbol AND it
+    // matches the six-character accession form. Searching the accession space
+    // alone reports the target of clopidogrel as absent.
+    it("searches both spaces for an accession-shaped input", async () => {
+        stubResponse(200, readFixture("uniprot", "search_BRCA1_reviewed.json"));
+
+        await callSearchProtein({ query: "P2RY12" });
+
+        expect(sentQuery()).toBe("(accession:P2RY12 OR (gene_exact:P2RY12 AND organism_id:9606 AND reviewed:true))");
+    });
+
+    // An accession is a unique key, thus the narrowing filters must not reach
+    // it. `accession:P02769 AND organism_id:9606` answers nothing, although the
+    // accession names bovine serum albumin.
+    it("keeps the organism and reviewed filters off the accession clause", async () => {
+        stubResponse(200, readFixture("uniprot", "search_BRCA1_reviewed.json"));
+
+        await callSearchProtein({ query: "P02769" });
+
+        const query = sentQuery();
+        expect(query.slice(0, query.indexOf(" OR "))).toBe("(accession:P02769");
     });
 
     it("recognizes the ten-character accession form", async () => {
@@ -79,7 +105,7 @@ describe("searchProtein — a resolved symbol", () => {
 
         await callSearchProtein({ query: "A0A0B4J1Y9" });
 
-        expect(sentQuery()).toContain("accession:A0A0B4J1Y9");
+        expect(sentQuery()).toContain("accession:A0A0B4J1Y9 OR");
     });
 
     it("drops the organism clause when organismId is null", async () => {
@@ -96,6 +122,29 @@ describe("searchProtein — a resolved symbol", () => {
         await callSearchProtein({ query: "BRCA1", reviewedOnly: false });
 
         expect(sentQuery()).toBe("gene_exact:BRCA1 AND organism_id:9606");
+    });
+});
+
+describe("searchProtein — a TrEMBL entry", () => {
+    // `UniProtKB unreviewed (TrEMBL)` HOLDS the word `reviewed`, thus a
+    // substring test for it reports every uncurated entry as curated.
+    it("reports reviewed false, and reads the name from submissionNames", async () => {
+        stubResponse(200, readFixture("uniprot", "search_X5D778_trembl.json"));
+
+        const out = await callSearchProtein({ query: "X5D778", reviewedOnly: false });
+
+        const protein = out.proteins[0]!;
+        expect(protein.accession).toBe("X5D778");
+        expect(protein.reviewed).toBe(false);
+        expect(protein.proteinName).toBe("Ankyrin repeat domain 11 isoform A");
+    });
+
+    it("reports reviewed true for a Swiss-Prot entry", async () => {
+        stubResponse(200, readFixture("uniprot", "search_BRCA1_reviewed.json"));
+
+        const out = await callSearchProtein({ query: "BRCA1" });
+
+        expect(out.proteins[0]!.reviewed).toBe(true);
     });
 });
 

--- a/harness/src/tools/bio/search-protein.test.ts
+++ b/harness/src/tools/bio/search-protein.test.ts
@@ -85,7 +85,7 @@ describe("searchProtein — a resolved symbol", () => {
 
         await callSearchProtein({ query: "P2RY12" });
 
-        expect(sentQuery()).toBe("(accession:P2RY12 OR (gene_exact:P2RY12 AND organism_id:9606 AND reviewed:true))");
+        expect(sentQuery()).toBe("((accession:P2RY12 AND active:true) OR (gene_exact:P2RY12 AND organism_id:9606 AND reviewed:true))");
     });
 
     // An accession is a unique key, thus the narrowing filters must not reach
@@ -97,7 +97,19 @@ describe("searchProtein — a resolved symbol", () => {
         await callSearchProtein({ query: "P02769" });
 
         const query = sentQuery();
-        expect(query.slice(0, query.indexOf(" OR "))).toBe("(accession:P02769");
+        expect(query.slice(0, query.indexOf(" OR "))).toBe("((accession:P02769 AND active:true)");
+    });
+
+    // A deleted accession still answers an `accession:` query, as an `Inactive`
+    // row with no name and no function. `B3GAT1` is one: the gene symbol also
+    // names a deleted TrEMBL accession, thus without `active:true` the answer
+    // holds the human protein and a hollow second row.
+    it("binds active:true to the accession clause, thus a deleted accession does not answer", async () => {
+        stubResponse(200, readFixture("uniprot", "search_BRCA1_reviewed.json"));
+
+        await callSearchProtein({ query: "B3GAT1" });
+
+        expect(sentQuery()).toBe("((accession:B3GAT1 AND active:true) OR (gene_exact:B3GAT1 AND organism_id:9606 AND reviewed:true))");
     });
 
     it("recognizes the ten-character accession form", async () => {
@@ -105,7 +117,7 @@ describe("searchProtein — a resolved symbol", () => {
 
         await callSearchProtein({ query: "A0A0B4J1Y9" });
 
-        expect(sentQuery()).toContain("accession:A0A0B4J1Y9 OR");
+        expect(sentQuery()).toContain("accession:A0A0B4J1Y9 AND active:true");
     });
 
     it("drops the organism clause when organismId is null", async () => {

--- a/harness/src/tools/bio/search-protein.test.ts
+++ b/harness/src/tools/bio/search-protein.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { readFixture } from "../lib/__fixtures__/fixture-runner.js";
+import { makeToolContext } from "../__fixtures__/tool-context.js";
+import { searchProteinTool } from "./search-protein.js";
+
+const realFetch = globalThis.fetch;
+
+/** Every URL the tool asked for, in call order — the record of the query it built. */
+let requestedUrls: string[] = [];
+
+beforeEach(() => {
+    requestedUrls = [];
+});
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+function stubResponse(status: number, body: unknown): void {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+        requestedUrls.push(String(input));
+        return new Response(typeof body === "string" ? body : JSON.stringify(body), { status });
+    }) as unknown as typeof fetch;
+}
+
+/** The `query` parameter of the one request the tool made, decoded. */
+function sentQuery(): string {
+    return new URL(requestedUrls[0]!).searchParams.get("query")!;
+}
+
+type SearchProteinInput = Parameters<typeof searchProteinTool.execute>[0];
+
+const DEFAULTS = { organismId: 9606, reviewedOnly: true, limit: 10 } as const;
+
+async function callSearchProtein(input: Partial<SearchProteinInput> & { query: string }) {
+    const { ctx } = makeToolContext();
+    return (await searchProteinTool.execute({ ...DEFAULTS, ...input }, ctx))._unsafeUnwrap();
+}
+
+describe("searchProtein — a resolved symbol", () => {
+    it("maps the accession, the name, the length, the function, and the locations", async () => {
+        stubResponse(200, readFixture("uniprot", "search_BRCA1_reviewed.json"));
+
+        const out = await callSearchProtein({ query: "BRCA1" });
+
+        expect(out.proteins).toHaveLength(1);
+        const protein = out.proteins[0]!;
+        expect(protein.accession).toBe("P38398");
+        expect(protein.uniProtkbId).toBe("BRCA1_HUMAN");
+        expect(protein.proteinName).toBe("Breast cancer type 1 susceptibility protein");
+        expect(protein.geneNames).toEqual(["BRCA1"]);
+        expect(protein.sequenceLength).toBe(1863);
+        expect(protein.reviewed).toBe(true);
+        expect(protein.function).toContain("E3 ubiquitin-protein ligase");
+        // The locations are collected across every SUBCELLULAR LOCATION comment,
+        // and a location that UniProt repeats is kept once.
+        expect(protein.subcellularLocations).toEqual(["Nucleus", "Chromosome", "Cytoplasm"]);
+    });
+
+    it("queries gene_exact for a symbol, with the organism and the reviewed filter", async () => {
+        stubResponse(200, readFixture("uniprot", "search_BRCA1_reviewed.json"));
+
+        await callSearchProtein({ query: "BRCA1" });
+
+        expect(sentQuery()).toBe("gene_exact:BRCA1 AND organism_id:9606 AND reviewed:true");
+    });
+
+    it("queries accession for an input shaped like one", async () => {
+        stubResponse(200, readFixture("uniprot", "search_BRCA1_reviewed.json"));
+
+        await callSearchProtein({ query: "P38398" });
+
+        expect(sentQuery()).toBe("accession:P38398 AND organism_id:9606 AND reviewed:true");
+    });
+
+    it("recognizes the ten-character accession form", async () => {
+        stubResponse(200, readFixture("uniprot", "search_BRCA1_reviewed.json"));
+
+        await callSearchProtein({ query: "A0A0B4J1Y9" });
+
+        expect(sentQuery()).toContain("accession:A0A0B4J1Y9");
+    });
+
+    it("drops the organism clause when organismId is null", async () => {
+        stubResponse(200, readFixture("uniprot", "search_BRCA1_reviewed.json"));
+
+        await callSearchProtein({ query: "BRCA1", organismId: null });
+
+        expect(sentQuery()).toBe("gene_exact:BRCA1 AND reviewed:true");
+    });
+
+    it("drops the reviewed clause when reviewedOnly is false", async () => {
+        stubResponse(200, readFixture("uniprot", "search_BRCA1_reviewed.json"));
+
+        await callSearchProtein({ query: "BRCA1", reviewedOnly: false });
+
+        expect(sentQuery()).toBe("gene_exact:BRCA1 AND organism_id:9606");
+    });
+});
+
+describe("searchProtein — an entry that omits the optional keys", () => {
+    it("maps the absent genes and comments to empty values, not to an error", async () => {
+        stubResponse(200, readFixture("uniprot", "search_Q6ZQY7_sparse.json"));
+
+        const out = await callSearchProtein({ query: "Q6ZQY7" });
+
+        const protein = out.proteins[0]!;
+        expect(protein.accession).toBe("Q6ZQY7");
+        expect(protein.geneNames).toEqual([]);
+        expect(protein.function).toBeNull();
+        expect(protein.subcellularLocations).toEqual([]);
+    });
+});
+
+describe("searchProtein — no match", () => {
+    // UniProt answers an unknown query with HTTP 200 and an empty array, never
+    // a 404, thus the empty case has no status-code branch at all.
+    it("returns an empty proteins array, not an is_error", async () => {
+        stubResponse(200, { results: [] });
+
+        const out = await callSearchProtein({ query: "NOTAGENE123" });
+
+        expect(out).toEqual({ proteins: [], hasMore: false });
+    });
+});
+
+describe("searchProtein — the bound on the answer", () => {
+    it("trims to the limit and reports that more rows existed", async () => {
+        const row = (readFixture("uniprot", "search_BRCA1_reviewed.json") as { results: unknown[] }).results[0]!;
+        // The client asks for `limit + 1` rows, thus three rows for a limit of 2
+        // is what "UniProt held more" looks like on the wire.
+        stubResponse(200, { results: [row, row, row] });
+
+        const out = await callSearchProtein({ query: "BRCA1", reviewedOnly: false, limit: 2 });
+
+        expect(out.proteins).toHaveLength(2);
+        expect(out.hasMore).toBe(true);
+        expect(new URL(requestedUrls[0]!).searchParams.get("size")).toBe("3");
+    });
+
+    it("reports hasMore false when the answer fits inside the limit", async () => {
+        stubResponse(200, readFixture("uniprot", "search_BRCA1_reviewed.json"));
+
+        const out = await callSearchProtein({ query: "BRCA1", limit: 2 });
+
+        expect(out.hasMore).toBe(false);
+    });
+});
+
+describe("searchProtein — an upstream failure", () => {
+    it("throws on a 5xx", async () => {
+        stubResponse(500, "upstream down");
+
+        const { ctx } = makeToolContext();
+        await expect(searchProteinTool.execute({ ...DEFAULTS, query: "BRCA1" }, ctx)).rejects.toThrow();
+    });
+});
+
+describe("searchProtein — describeCall", () => {
+    it("names the query", () => {
+        expect(searchProteinTool.describeCall!({ ...DEFAULTS, query: "BRCA1" })).toBe("BRCA1");
+    });
+});

--- a/harness/src/tools/bio/search-protein.ts
+++ b/harness/src/tools/bio/search-protein.ts
@@ -1,0 +1,72 @@
+/**
+ * searchProtein — resolve a protein against UniProtKB.
+ *
+ * `search_gene` accepts a UniProt accession, but it answers with Ensembl gene
+ * records, thus nothing gave an agent the protein itself: the name, the length,
+ * the curated function, and where in the cell it acts. This tool answers that,
+ * and its accession is the key that the structural tools take.
+ */
+
+import { ok, type Result } from "neverthrow";
+import { z } from "zod";
+
+import { defineTool, type ToolError } from "../define-tool.js";
+import { searchProteins, type UniProtProtein } from "../lib/uniprot-client.js";
+
+/** Rows returned by default. An exact gene symbol resolves to one reviewed protein. */
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
+export interface SearchProteinOutput {
+    readonly proteins: UniProtProtein[];
+    /** True when UniProt held at least one row beyond `limit`. */
+    readonly hasMore: boolean;
+}
+
+export const searchProteinTool = defineTool({
+    id: "search_protein",
+    description:
+        "UniProtKB — the curated protein knowledgebase of EMBL-EBI, SIB and PIR. Resolves a protein and answers with its accession, its UniProtKB ID " +
+        "('BRCA1_HUMAN'), its recommended name, its gene names, its sequence length, its curated FUNCTION summary, and its subcellular locations.\n" +
+        "ACCEPTED IDENTIFIERS: a HUGO gene symbol ('BRCA1'), matched exactly, or a UniProt accession ('P38398', 'A0A0B4J1Y9'), which is detected by its " +
+        "shape and looked up directly. A protein NAME is not accepted — resolve the symbol first.\n" +
+        "This is the tool that produces a UniProt accession, which is the key that the structure tools take. Prefer it over search_gene when the " +
+        "question is about the PROTEIN — what it does, how long it is, where it acts — and search_gene when the question is about the gene locus, its " +
+        "coordinates or its Ensembl ID.\n" +
+        "`reviewedOnly` defaults to true, thus an answer holds Swiss-Prot entries only: manually curated, one entry per gene, and the right default for " +
+        "a human question. Set it false to reach TrEMBL as well, which is machine-annotated and holds many isoform-level rows per gene — needed for a " +
+        "protein that Swiss-Prot has not curated.\n" +
+        "`organismId` takes an NCBI Taxonomy ID and defaults to 9606 (human); pass 10090 for mouse, or null to search every organism.\n" +
+        "An empty `proteins` array is valid no-data (an unrecognized symbol, or one this organism has no entry for) — report it and continue, do not " +
+        "retry the same call. `hasMore` true means the answer was trimmed to `limit`.",
+    inputSchema: z.object({
+        query: z.string().min(1).describe("A gene symbol ('BRCA1') or a UniProt accession ('P38398')."),
+        organismId: z
+            .number()
+            .int()
+            .positive()
+            .nullable()
+            .default(9606)
+            .describe("NCBI Taxonomy ID (9606 = human, 10090 = mouse). Null searches every organism, which is how to reach a non-model species."),
+        reviewedOnly: z.boolean().default(true).describe("True (default) keeps Swiss-Prot entries only. False also returns machine-annotated TrEMBL entries."),
+        limit: z
+            .number()
+            .int()
+            .min(1)
+            .max(MAX_LIMIT)
+            .default(DEFAULT_LIMIT)
+            .describe(
+                `Max proteins returned (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}). An exact symbol under reviewedOnly resolves to one entry, so raise ` +
+                    "this only for a reviewedOnly=false survey, where a gene carries many TrEMBL rows.",
+            ),
+    }),
+    describeCall: ({ query }) => query,
+    execute: async ({ query, organismId, reviewedOnly, limit }): Promise<Result<SearchProteinOutput, ToolError>> => {
+        const result = await searchProteins(query, {
+            ...(organismId === null ? {} : { organismId }),
+            reviewedOnly,
+            limit,
+        });
+        return ok(result);
+    },
+});

--- a/harness/src/tools/bio/search-protein.ts
+++ b/harness/src/tools/bio/search-protein.ts
@@ -28,15 +28,17 @@ export const searchProteinTool = defineTool({
     description:
         "UniProtKB — the curated protein knowledgebase of EMBL-EBI, SIB and PIR. Resolves a protein and answers with its accession, its UniProtKB ID " +
         "('BRCA1_HUMAN'), its recommended name, its gene names, its sequence length, its curated FUNCTION summary, and its subcellular locations.\n" +
-        "ACCEPTED IDENTIFIERS: a HUGO gene symbol ('BRCA1'), matched exactly, or a UniProt accession ('P38398', 'A0A0B4J1Y9'), which is detected by its " +
-        "shape and looked up directly. A protein NAME is not accepted — resolve the symbol first.\n" +
+        "ACCEPTED IDENTIFIERS: a HUGO gene symbol ('BRCA1'), matched exactly, or a UniProt accession ('P38398', 'A0A0B4J1Y9'). The two spaces overlap — " +
+        "'P2RY12' is both a real symbol and a valid accession shape — so an accession-shaped input searches BOTH, and either kind resolves. A protein " +
+        "NAME is not accepted; resolve the symbol first.\n" +
         "This is the tool that produces a UniProt accession, which is the key that the structure tools take. Prefer it over search_gene when the " +
         "question is about the PROTEIN — what it does, how long it is, where it acts — and search_gene when the question is about the gene locus, its " +
         "coordinates or its Ensembl ID.\n" +
         "`reviewedOnly` defaults to true, thus an answer holds Swiss-Prot entries only: manually curated, one entry per gene, and the right default for " +
         "a human question. Set it false to reach TrEMBL as well, which is machine-annotated and holds many isoform-level rows per gene — needed for a " +
         "protein that Swiss-Prot has not curated.\n" +
-        "`organismId` takes an NCBI Taxonomy ID and defaults to 9606 (human); pass 10090 for mouse, or null to search every organism.\n" +
+        "`organismId` takes an NCBI Taxonomy ID and defaults to 9606 (human); pass 10090 for mouse, or null to search every organism. Both this and " +
+        "`reviewedOnly` narrow a SYMBOL match only — an accession is a unique key, so it resolves whatever its organism or review status.\n" +
         "An empty `proteins` array is valid no-data (an unrecognized symbol, or one this organism has no entry for) — report it and continue, do not " +
         "retry the same call. `hasMore` true means the answer was trimmed to `limit`.",
     inputSchema: z.object({

--- a/harness/src/tools/lib/__fixtures__/uniprot/manifest.json
+++ b/harness/src/tools/lib/__fixtures__/uniprot/manifest.json
@@ -7,6 +7,32 @@
         "url": "https://rest.uniprot.org/uniprotkb/Q6ZQY7?fields=accession,id,gene_names,xref_chembl,xref_reactome,cc_similarity&format=json",
         "capturedAt": "2026-08-28"
     },
+    "search_BRCA1_reviewed.json": {
+        "url": "https://rest.uniprot.org/uniprotkb/search",
+        "params": {
+            "query": "gene_exact:BRCA1 AND organism_id:9606 AND reviewed:true",
+            "fields": "accession,id,protein_name,gene_names,length,cc_function,cc_subcellular_location",
+            "format": "json",
+            "size": "2"
+        },
+        "headers": {
+            "Accept": "application/json"
+        },
+        "capturedAt": "2026-09-08"
+    },
+    "search_Q6ZQY7_sparse.json": {
+        "url": "https://rest.uniprot.org/uniprotkb/search",
+        "params": {
+            "query": "accession:Q6ZQY7",
+            "fields": "accession,id,protein_name,gene_names,length,cc_function,cc_subcellular_location",
+            "format": "json",
+            "size": "2"
+        },
+        "headers": {
+            "Accept": "application/json"
+        },
+        "capturedAt": "2026-09-08"
+    },
     "uniprotkb_openapi.json": {
         "url": "https://rest.uniprot.org/uniprotkb/api/docs",
         "capturedAt": "2026-08-28",

--- a/harness/src/tools/lib/__fixtures__/uniprot/manifest.json
+++ b/harness/src/tools/lib/__fixtures__/uniprot/manifest.json
@@ -33,6 +33,19 @@
         },
         "capturedAt": "2026-09-08"
     },
+    "search_X5D778_trembl.json": {
+        "url": "https://rest.uniprot.org/uniprotkb/search",
+        "params": {
+            "query": "accession:X5D778",
+            "fields": "accession,id,protein_name,gene_names,length,cc_function,cc_subcellular_location",
+            "format": "json",
+            "size": "2"
+        },
+        "headers": {
+            "Accept": "application/json"
+        },
+        "capturedAt": "2026-09-08"
+    },
     "uniprotkb_openapi.json": {
         "url": "https://rest.uniprot.org/uniprotkb/api/docs",
         "capturedAt": "2026-08-28",

--- a/harness/src/tools/lib/__fixtures__/uniprot/search_BRCA1_reviewed.drift.json
+++ b/harness/src/tools/lib/__fixtures__/uniprot/search_BRCA1_reviewed.drift.json
@@ -1,0 +1,304 @@
+{
+    "results": [
+        {
+            "entryType": "UniProtKB reviewed (Swiss-Prot)",
+            "primaryAccession": "P38398",
+            "uniProtkbId": "BRCA1_HUMAN",
+            "proteinDescription": {
+                "recommendedName": {
+                    "fullName": {
+                        "value": "Breast cancer type 1 susceptibility protein"
+                    },
+                    "ecNumbers": [
+                        {
+                            "evidences": [
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "10500182"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "12887909"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "12890688"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "16818604"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "18056443"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "20351172"
+                                }
+                            ],
+                            "value": "2.3.2.27"
+                        }
+                    ]
+                },
+                "alternativeNames": [
+                    {
+                        "fullName": {
+                            "value": "RING finger protein 53"
+                        }
+                    },
+                    {
+                        "fullName": {
+                            "evidences": [
+                                {
+                                    "evidenceCode": "ECO:0000305"
+                                }
+                            ],
+                            "value": "RING-type E3 ubiquitin transferase BRCA1"
+                        }
+                    }
+                ]
+            },
+            "genes": [
+                {
+                    "geneName": {
+                        "value": "BRCA1"
+                    },
+                    "synonyms": [
+                        {
+                            "value": "RNF53"
+                        }
+                    ]
+                }
+            ],
+            "comments": [
+                {
+                    "texts": [
+                        {
+                            "evidences": [
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "10500182"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "10724175"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "11836499"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "12183412"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "12887909"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "12890688"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "14976165"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "16326698"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "16818604"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "17525340"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "18056443"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "19261748"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "19369211"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "20160719"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "20351172"
+                                }
+                            ],
+                            "value": "E3 ubiquitin-protein ligase that specifically mediates the formation of 'Lys-6'-linked polyubiquitin chains and plays a central role in DNA repair by facilitating cellular responses to DNA damage (PubMed:10500182, PubMed:12887909, PubMed:12890688, PubMed:14976165, PubMed:16818604, PubMed:17525340, PubMed:19261748). It is unclear whether it also mediates the formation of other types of polyubiquitin chains (PubMed:12890688). The BRCA1-BARD1 heterodimer coordinates a diverse range of cellular pathways such as DNA damage repair, ubiquitination and transcriptional regulation to maintain genomic stability (PubMed:12890688, PubMed:14976165, PubMed:20351172). Regulates centrosomal microtubule nucleation (PubMed:18056443). Required for appropriate cell cycle arrests after ionizing irradiation in both the S-phase and the G2 phase of the cell cycle (PubMed:10724175, PubMed:11836499, PubMed:12183412, PubMed:19261748). Required for FANCD2 targeting to sites of DNA damage (PubMed:12887909). Inhibits lipid synthesis by binding to inactive phosphorylated ACACA and preventing its dephosphorylation (PubMed:16326698). Contributes to homologous recombination repair (HRR) via its direct interaction with PALB2, fine-tunes recombinational repair partly through its modulatory role in the PALB2-dependent loading of BRCA2-RAD51 repair machinery at DNA breaks (PubMed:19369211). Component of the BRCA1-RBBP8 complex which regulates CHEK1 activation and controls cell cycle G2/M checkpoints on DNA damage via BRCA1-mediated ubiquitination of RBBP8 (PubMed:16818604). Acts as a transcriptional activator (PubMed:20160719)"
+                        }
+                    ],
+                    "commentType": "FUNCTION"
+                },
+                {
+                    "commentType": "SUBCELLULAR LOCATION",
+                    "note": {
+                        "texts": [
+                            {
+                                "evidences": [
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "20160719"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "26778126"
+                                    }
+                                ],
+                                "value": "Localizes at sites of DNA damage at double-strand breaks (DSBs); recruitment to DNA damage sites is mediated by ABRAXAS1 and the BRCA1-A complex (PubMed:26778126). Translocated to the cytoplasm during UV-induced apoptosis (PubMed:20160719)"
+                            }
+                        ]
+                    },
+                    "subcellularLocations": [
+                        {
+                            "location": {
+                                "evidences": [
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "15133502"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "17525340"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "20160719"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "21144835"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "26778126"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "9528852"
+                                    }
+                                ],
+                                "value": "Nucleus",
+                                "id": "SL-0191"
+                            }
+                        },
+                        {
+                            "location": {
+                                "evidences": [
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "23269703"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "25472942"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "26778126"
+                                    }
+                                ],
+                                "value": "Chromosome",
+                                "id": "SL-0468"
+                            }
+                        },
+                        {
+                            "location": {
+                                "evidences": [
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "20160719"
+                                    }
+                                ],
+                                "value": "Cytoplasm",
+                                "id": "SL-0086"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "commentType": "SUBCELLULAR LOCATION",
+                    "molecule": "Isoform 3",
+                    "subcellularLocations": [
+                        {
+                            "location": {
+                                "value": "Cytoplasm",
+                                "id": "SL-0086"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "commentType": "SUBCELLULAR LOCATION",
+                    "molecule": "Isoform 5",
+                    "subcellularLocations": [
+                        {
+                            "location": {
+                                "evidences": [
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "8972225"
+                                    }
+                                ],
+                                "value": "Cytoplasm",
+                                "id": "SL-0086"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "sequence": {
+                "length": "1863"
+            },
+            "extraAttributes": {
+                "uniParcId": "UPI0000126AC8"
+            }
+        }
+    ]
+}

--- a/harness/src/tools/lib/__fixtures__/uniprot/search_BRCA1_reviewed.json
+++ b/harness/src/tools/lib/__fixtures__/uniprot/search_BRCA1_reviewed.json
@@ -1,0 +1,304 @@
+{
+    "results": [
+        {
+            "entryType": "UniProtKB reviewed (Swiss-Prot)",
+            "primaryAccession": "P38398",
+            "uniProtkbId": "BRCA1_HUMAN",
+            "proteinDescription": {
+                "recommendedName": {
+                    "fullName": {
+                        "value": "Breast cancer type 1 susceptibility protein"
+                    },
+                    "ecNumbers": [
+                        {
+                            "evidences": [
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "10500182"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "12887909"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "12890688"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "16818604"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "18056443"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "20351172"
+                                }
+                            ],
+                            "value": "2.3.2.27"
+                        }
+                    ]
+                },
+                "alternativeNames": [
+                    {
+                        "fullName": {
+                            "value": "RING finger protein 53"
+                        }
+                    },
+                    {
+                        "fullName": {
+                            "evidences": [
+                                {
+                                    "evidenceCode": "ECO:0000305"
+                                }
+                            ],
+                            "value": "RING-type E3 ubiquitin transferase BRCA1"
+                        }
+                    }
+                ]
+            },
+            "genes": [
+                {
+                    "geneName": {
+                        "value": "BRCA1"
+                    },
+                    "synonyms": [
+                        {
+                            "value": "RNF53"
+                        }
+                    ]
+                }
+            ],
+            "comments": [
+                {
+                    "texts": [
+                        {
+                            "evidences": [
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "10500182"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "10724175"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "11836499"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "12183412"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "12887909"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "12890688"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "14976165"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "16326698"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "16818604"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "17525340"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "18056443"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "19261748"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "19369211"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "20160719"
+                                },
+                                {
+                                    "evidenceCode": "ECO:0000269",
+                                    "source": "PubMed",
+                                    "id": "20351172"
+                                }
+                            ],
+                            "value": "E3 ubiquitin-protein ligase that specifically mediates the formation of 'Lys-6'-linked polyubiquitin chains and plays a central role in DNA repair by facilitating cellular responses to DNA damage (PubMed:10500182, PubMed:12887909, PubMed:12890688, PubMed:14976165, PubMed:16818604, PubMed:17525340, PubMed:19261748). It is unclear whether it also mediates the formation of other types of polyubiquitin chains (PubMed:12890688). The BRCA1-BARD1 heterodimer coordinates a diverse range of cellular pathways such as DNA damage repair, ubiquitination and transcriptional regulation to maintain genomic stability (PubMed:12890688, PubMed:14976165, PubMed:20351172). Regulates centrosomal microtubule nucleation (PubMed:18056443). Required for appropriate cell cycle arrests after ionizing irradiation in both the S-phase and the G2 phase of the cell cycle (PubMed:10724175, PubMed:11836499, PubMed:12183412, PubMed:19261748). Required for FANCD2 targeting to sites of DNA damage (PubMed:12887909). Inhibits lipid synthesis by binding to inactive phosphorylated ACACA and preventing its dephosphorylation (PubMed:16326698). Contributes to homologous recombination repair (HRR) via its direct interaction with PALB2, fine-tunes recombinational repair partly through its modulatory role in the PALB2-dependent loading of BRCA2-RAD51 repair machinery at DNA breaks (PubMed:19369211). Component of the BRCA1-RBBP8 complex which regulates CHEK1 activation and controls cell cycle G2/M checkpoints on DNA damage via BRCA1-mediated ubiquitination of RBBP8 (PubMed:16818604). Acts as a transcriptional activator (PubMed:20160719)"
+                        }
+                    ],
+                    "commentType": "FUNCTION"
+                },
+                {
+                    "commentType": "SUBCELLULAR LOCATION",
+                    "note": {
+                        "texts": [
+                            {
+                                "evidences": [
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "20160719"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "26778126"
+                                    }
+                                ],
+                                "value": "Localizes at sites of DNA damage at double-strand breaks (DSBs); recruitment to DNA damage sites is mediated by ABRAXAS1 and the BRCA1-A complex (PubMed:26778126). Translocated to the cytoplasm during UV-induced apoptosis (PubMed:20160719)"
+                            }
+                        ]
+                    },
+                    "subcellularLocations": [
+                        {
+                            "location": {
+                                "evidences": [
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "15133502"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "17525340"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "20160719"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "21144835"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "26778126"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "9528852"
+                                    }
+                                ],
+                                "value": "Nucleus",
+                                "id": "SL-0191"
+                            }
+                        },
+                        {
+                            "location": {
+                                "evidences": [
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "23269703"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "25472942"
+                                    },
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "26778126"
+                                    }
+                                ],
+                                "value": "Chromosome",
+                                "id": "SL-0468"
+                            }
+                        },
+                        {
+                            "location": {
+                                "evidences": [
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "20160719"
+                                    }
+                                ],
+                                "value": "Cytoplasm",
+                                "id": "SL-0086"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "commentType": "SUBCELLULAR LOCATION",
+                    "molecule": "Isoform 3",
+                    "subcellularLocations": [
+                        {
+                            "location": {
+                                "value": "Cytoplasm",
+                                "id": "SL-0086"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "commentType": "SUBCELLULAR LOCATION",
+                    "molecule": "Isoform 5",
+                    "subcellularLocations": [
+                        {
+                            "location": {
+                                "evidences": [
+                                    {
+                                        "evidenceCode": "ECO:0000269",
+                                        "source": "PubMed",
+                                        "id": "8972225"
+                                    }
+                                ],
+                                "value": "Cytoplasm",
+                                "id": "SL-0086"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "sequence": {
+                "length": 1863
+            },
+            "extraAttributes": {
+                "uniParcId": "UPI0000126AC8"
+            }
+        }
+    ]
+}

--- a/harness/src/tools/lib/__fixtures__/uniprot/search_Q6ZQY7_sparse.drift.json
+++ b/harness/src/tools/lib/__fixtures__/uniprot/search_Q6ZQY7_sparse.drift.json
@@ -1,0 +1,20 @@
+{
+    "results": {
+        "entryType": "UniProtKB reviewed (Swiss-Prot)",
+        "primaryAccession": "Q6ZQY7",
+        "uniProtkbId": "YO026_HUMAN",
+        "proteinDescription": {
+            "recommendedName": {
+                "fullName": {
+                    "value": "Putative uncharacterized protein FLJ46792"
+                }
+            }
+        },
+        "sequence": {
+            "length": 126
+        },
+        "extraAttributes": {
+            "uniParcId": "UPI00001C104E"
+        }
+    }
+}

--- a/harness/src/tools/lib/__fixtures__/uniprot/search_Q6ZQY7_sparse.json
+++ b/harness/src/tools/lib/__fixtures__/uniprot/search_Q6ZQY7_sparse.json
@@ -1,0 +1,22 @@
+{
+    "results": [
+        {
+            "entryType": "UniProtKB reviewed (Swiss-Prot)",
+            "primaryAccession": "Q6ZQY7",
+            "uniProtkbId": "YO026_HUMAN",
+            "proteinDescription": {
+                "recommendedName": {
+                    "fullName": {
+                        "value": "Putative uncharacterized protein FLJ46792"
+                    }
+                }
+            },
+            "sequence": {
+                "length": 126
+            },
+            "extraAttributes": {
+                "uniParcId": "UPI00001C104E"
+            }
+        }
+    ]
+}

--- a/harness/src/tools/lib/__fixtures__/uniprot/search_X5D778_trembl.drift.json
+++ b/harness/src/tools/lib/__fixtures__/uniprot/search_X5D778_trembl.drift.json
@@ -1,0 +1,47 @@
+{
+    "results": [
+        {
+            "entryType": 1,
+            "primaryAccession": "X5D778",
+            "uniProtkbId": "X5D778_HUMAN",
+            "proteinDescription": {
+                "submissionNames": [
+                    {
+                        "fullName": {
+                            "evidences": [
+                                {
+                                    "evidenceCode": "ECO:0000313",
+                                    "source": "EMBL",
+                                    "id": "AHW56410.1"
+                                }
+                            ],
+                            "value": "Ankyrin repeat domain 11 isoform A"
+                        }
+                    }
+                ],
+                "flag": "Fragment"
+            },
+            "genes": [
+                {
+                    "geneName": {
+                        "evidences": [
+                            {
+                                "evidenceCode": "ECO:0000313",
+                                "source": "EMBL",
+                                "id": "AHW56410.1"
+                            }
+                        ],
+                        "value": "ANKRD11"
+                    }
+                }
+            ],
+            "comments": [],
+            "sequence": {
+                "length": 421
+            },
+            "extraAttributes": {
+                "uniParcId": "UPI0004437BC2"
+            }
+        }
+    ]
+}

--- a/harness/src/tools/lib/__fixtures__/uniprot/search_X5D778_trembl.json
+++ b/harness/src/tools/lib/__fixtures__/uniprot/search_X5D778_trembl.json
@@ -1,0 +1,47 @@
+{
+    "results": [
+        {
+            "entryType": "UniProtKB unreviewed (TrEMBL)",
+            "primaryAccession": "X5D778",
+            "uniProtkbId": "X5D778_HUMAN",
+            "proteinDescription": {
+                "submissionNames": [
+                    {
+                        "fullName": {
+                            "evidences": [
+                                {
+                                    "evidenceCode": "ECO:0000313",
+                                    "source": "EMBL",
+                                    "id": "AHW56410.1"
+                                }
+                            ],
+                            "value": "Ankyrin repeat domain 11 isoform A"
+                        }
+                    }
+                ],
+                "flag": "Fragment"
+            },
+            "genes": [
+                {
+                    "geneName": {
+                        "evidences": [
+                            {
+                                "evidenceCode": "ECO:0000313",
+                                "source": "EMBL",
+                                "id": "AHW56410.1"
+                            }
+                        ],
+                        "value": "ANKRD11"
+                    }
+                }
+            ],
+            "comments": [],
+            "sequence": {
+                "length": 421
+            },
+            "extraAttributes": {
+                "uniParcId": "UPI0004437BC2"
+            }
+        }
+    ]
+}

--- a/harness/src/tools/lib/uniprot-client.ts
+++ b/harness/src/tools/lib/uniprot-client.ts
@@ -290,6 +290,13 @@ export function isUniProtAccession(query: string): boolean {
  * overlap. Such an input searches both, and the unfiltered accession clause is
  * OR-ed with the filtered symbol clause. An input that is not
  * accession-shaped searches the symbol space alone.
+ *
+ * The accession side carries `active:true`, and that is the one filter it
+ * takes. A deleted accession still answers an `accession:` query, as an
+ * `Inactive` row with no name and no function, and `UniProtProtein` has no
+ * field for the deletion reason. `B3GAT1` is such a case: the gene symbol also
+ * names a deleted TrEMBL accession, thus without the filter the answer holds
+ * the human protein and a hollow second row.
  */
 function buildSearchQuery(query: string, organismId: number | undefined, reviewedOnly: boolean): string {
     const symbolClauses = [`gene_exact:${query}`];
@@ -298,7 +305,7 @@ function buildSearchQuery(query: string, organismId: number | undefined, reviewe
     const symbolQuery = symbolClauses.join(" AND ");
 
     if (!isUniProtAccession(query)) return symbolQuery;
-    return `(accession:${query} OR (${symbolQuery}))`;
+    return `((accession:${query} AND active:true) OR (${symbolQuery}))`;
 }
 
 export interface SearchProteinsOptions {

--- a/harness/src/tools/lib/uniprot-client.ts
+++ b/harness/src/tools/lib/uniprot-client.ts
@@ -117,3 +117,185 @@ export async function getReactomePathwaysByUniProt(accession: string): Promise<s
     const rec = await getUniProtRecord(accession);
     return rec?.reactomePathwayIds ?? [];
 }
+
+/** One protein of a UniProtKB search. */
+export interface UniProtProtein {
+    accession: string;
+    /** The UniProtKB ID, for example `BRCA1_HUMAN`. */
+    uniProtkbId: string | null;
+    proteinName: string | null;
+    geneNames: string[];
+    sequenceLength: number | null;
+    /** The curated FUNCTION comment, trimmed to a readable length. */
+    function: string | null;
+    /** The distinct curated subcellular locations, in the order UniProt lists them. */
+    subcellularLocations: string[];
+    /** True for a Swiss-Prot entry, false for a TrEMBL entry. */
+    reviewed: boolean;
+}
+
+/**
+ * The field list of the search. It is separate from `FIELDS` on purpose:
+ * `FIELDS` feeds `getUniProtRecord` and the target-assessment dossier, thus a
+ * widening of it would change what that workflow reads.
+ */
+const SEARCH_FIELDS = ["accession", "id", "protein_name", "gene_names", "length", "cc_function", "cc_subcellular_location"].join(",");
+
+/** A FUNCTION comment runs to several hundred words; this is what one answer carries. */
+const MAX_FUNCTION_CHARS = 1200;
+
+/** Swiss-Prot marks a reviewed entry in `entryType`, which reads `UniProtKB reviewed (Swiss-Prot)`. */
+const REVIEWED_ENTRY_TYPE = "reviewed";
+
+const SearchCommentSchema = z.object({
+    commentType: z.string().optional(),
+    texts: z.array(z.object({ value: z.string().optional() })).optional(),
+    subcellularLocations: z.array(z.object({ location: z.object({ value: z.string().optional() }).optional() })).optional(),
+});
+
+const ProteinNameSchema = z.object({ fullName: z.object({ value: z.string().optional() }).optional() });
+
+/**
+ * One result row of `uniprotkb/search`, with the same all-optional discipline as
+ * `UniProtRecordSchema`: UniProt omits the key of an absent value, thus every
+ * field carries `.optional()` and none carries `.nullable()`.
+ *
+ * A TrEMBL row can carry `submissionNames` in place of `recommendedName`
+ * (`X5D778` is one), thus the name reader falls back rather than reporting the
+ * protein as unnamed.
+ */
+export const UniProtSearchResultSchema = z.object({
+    primaryAccession: z.string().optional(),
+    uniProtkbId: z.string().optional(),
+    entryType: z.string().optional(),
+    proteinDescription: z
+        .object({
+            recommendedName: ProteinNameSchema.optional(),
+            submissionNames: z.array(ProteinNameSchema).optional(),
+        })
+        .optional(),
+    genes: z.array(z.object({ geneName: z.object({ value: z.string().optional() }).optional() })).optional(),
+    sequence: z.object({ length: z.number().optional() }).optional(),
+    comments: z.array(SearchCommentSchema).optional(),
+});
+
+/** The search envelope. It is exported so that the golden-fixture table drives it. */
+export const UniProtSearchResponseSchema = z.object({
+    results: z.array(UniProtSearchResultSchema).optional(),
+});
+
+type UniProtSearchResult = z.infer<typeof UniProtSearchResultSchema>;
+
+/** Read the protein name, preferring the recommended name over a submitted one. */
+function extractProteinName(raw: UniProtSearchResult): string | null {
+    const description = raw.proteinDescription;
+    const recommended = description?.recommendedName?.fullName?.value?.trim();
+    if (recommended) return recommended;
+    for (const submitted of description?.submissionNames ?? []) {
+        const value = submitted.fullName?.value?.trim();
+        if (value) return value;
+    }
+    return null;
+}
+
+/** Read the first FUNCTION comment, capped at {@link MAX_FUNCTION_CHARS}. */
+function extractFunctionText(raw: UniProtSearchResult): string | null {
+    for (const comment of raw.comments ?? []) {
+        if (comment.commentType !== "FUNCTION") continue;
+        for (const text of comment.texts ?? []) {
+            const value = text.value?.trim();
+            if (value) return value.length > MAX_FUNCTION_CHARS ? `${value.slice(0, MAX_FUNCTION_CHARS)}…` : value;
+        }
+    }
+    return null;
+}
+
+/**
+ * Read the distinct subcellular locations. UniProt splits them over more than
+ * one SUBCELLULAR LOCATION comment, and it repeats a location across them, thus
+ * the reader collects across every comment and keeps the first occurrence only.
+ */
+function extractSubcellularLocations(raw: UniProtSearchResult): string[] {
+    const locations: string[] = [];
+    const seen = new Set<string>();
+    for (const comment of raw.comments ?? []) {
+        if (comment.commentType !== "SUBCELLULAR LOCATION") continue;
+        for (const entry of comment.subcellularLocations ?? []) {
+            const value = entry.location?.value?.trim();
+            if (!value || seen.has(value)) continue;
+            seen.add(value);
+            locations.push(value);
+        }
+    }
+    return locations;
+}
+
+function toProtein(raw: UniProtSearchResult): UniProtProtein {
+    return {
+        accession: raw.primaryAccession ?? "",
+        uniProtkbId: raw.uniProtkbId ?? null,
+        proteinName: extractProteinName(raw),
+        geneNames: (raw.genes ?? []).map((gene) => gene.geneName?.value).filter((name): name is string => Boolean(name)),
+        sequenceLength: raw.sequence?.length ?? null,
+        function: extractFunctionText(raw),
+        subcellularLocations: extractSubcellularLocations(raw),
+        reviewed: (raw.entryType ?? "").toLowerCase().includes(REVIEWED_ENTRY_TYPE),
+    };
+}
+
+/**
+ * The accession forms that UniProt itself documents: the six-character form and
+ * the ten-character form, with an optional isoform suffix. A query that matches
+ * this is looked up as an accession, and every other query as a gene symbol.
+ */
+const ACCESSION_RE = /^(?:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2})(?:-\d+)?$/i;
+
+/** Does the query name a UniProt accession rather than a gene symbol? */
+export function isUniProtAccession(query: string): boolean {
+    return ACCESSION_RE.test(query.trim());
+}
+
+export interface SearchProteinsOptions {
+    /** NCBI taxonomy id; omit to search every organism. */
+    organismId?: number;
+    /** Swiss-Prot only when true (the default), Swiss-Prot and TrEMBL when false. */
+    reviewedOnly?: boolean;
+    /** Max rows returned. */
+    limit?: number;
+}
+
+export interface SearchProteinsResult {
+    proteins: UniProtProtein[];
+    /** True when UniProt held at least one row beyond `limit`. */
+    hasMore: boolean;
+}
+
+/**
+ * Search UniProtKB for a protein by gene symbol or by accession.
+ *
+ * An unknown query is HTTP 200 with `{"results":[]}`, never a 404, thus the
+ * empty result is an ordinary answer and never an error. The request asks for
+ * one row beyond `limit`, because UniProt reports its match count in the
+ * `x-total-results` header and `apiFetch` exposes no header. The extra row is
+ * what separates a trimmed answer from a complete one.
+ */
+export async function searchProteins(query: string, opts: SearchProteinsOptions = {}): Promise<SearchProteinsResult> {
+    const { organismId, reviewedOnly = true, limit = 10 } = opts;
+    const trimmed = query.trim();
+
+    const clauses = [isUniProtAccession(trimmed) ? `accession:${trimmed}` : `gene_exact:${trimmed}`];
+    if (organismId !== undefined) clauses.push(`organism_id:${organismId}`);
+    if (reviewedOnly) clauses.push("reviewed:true");
+
+    const params = new URLSearchParams({
+        query: clauses.join(" AND "),
+        fields: SEARCH_FIELDS,
+        format: "json",
+        size: String(limit + 1),
+    });
+    const res = await apiFetchValidated(`${UNIPROT_BASE}/uniprotkb/search?${params.toString()}`, UniProtSearchResponseSchema, { headers: UNIPROT_HEADERS });
+    if (res.isErr()) throw new Error(describeApiError(res.error));
+
+    const rows = res.value.results ?? [];
+    return { proteins: rows.slice(0, limit).map(toProtein), hasMore: rows.length > limit };
+}

--- a/harness/src/tools/lib/uniprot-client.ts
+++ b/harness/src/tools/lib/uniprot-client.ts
@@ -144,8 +144,21 @@ const SEARCH_FIELDS = ["accession", "id", "protein_name", "gene_names", "length"
 /** A FUNCTION comment runs to several hundred words; this is what one answer carries. */
 const MAX_FUNCTION_CHARS = 1200;
 
-/** Swiss-Prot marks a reviewed entry in `entryType`, which reads `UniProtKB reviewed (Swiss-Prot)`. */
+/**
+ * `entryType` reads `UniProtKB reviewed (Swiss-Prot)` or
+ * `UniProtKB unreviewed (TrEMBL)`. The unreviewed value HOLDS the reviewed one
+ * as a substring, thus the negative test must run first. A test for `reviewed`
+ * alone answers true for every entry of either kind.
+ */
 const REVIEWED_ENTRY_TYPE = "reviewed";
+const UNREVIEWED_ENTRY_TYPE = "unreviewed";
+
+/** Is the entry a curated Swiss-Prot record, as opposed to a machine-annotated TrEMBL one? */
+function isReviewedEntry(entryType: string | undefined): boolean {
+    const value = (entryType ?? "").toLowerCase();
+    if (value.includes(UNREVIEWED_ENTRY_TYPE)) return false;
+    return value.includes(REVIEWED_ENTRY_TYPE);
+}
 
 const SearchCommentSchema = z.object({
     commentType: z.string().optional(),
@@ -239,20 +252,53 @@ function toProtein(raw: UniProtSearchResult): UniProtProtein {
         sequenceLength: raw.sequence?.length ?? null,
         function: extractFunctionText(raw),
         subcellularLocations: extractSubcellularLocations(raw),
-        reviewed: (raw.entryType ?? "").toLowerCase().includes(REVIEWED_ENTRY_TYPE),
+        reviewed: isReviewedEntry(raw.entryType),
     };
 }
 
 /**
  * The accession forms that UniProt itself documents: the six-character form and
- * the ten-character form, with an optional isoform suffix. A query that matches
- * this is looked up as an accession, and every other query as a gene symbol.
+ * the ten-character form, with an optional isoform suffix.
+ *
+ * The shape does NOT tell an accession from a gene symbol, because the two
+ * spaces overlap: `P2RY12`, `B3GAT1`, and their siblings are real gene symbols
+ * that match this form. Thus the match decides only whether the `accession:`
+ * clause is SAFE to send, never which space the query names.
  */
 const ACCESSION_RE = /^(?:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2})(?:-\d+)?$/i;
 
-/** Does the query name a UniProt accession rather than a gene symbol? */
+/**
+ * Can the query ride in an `accession:` clause?
+ *
+ * UniProt validates the value of that clause, and it answers HTTP 400 for a
+ * value that is not accession-shaped. Thus a plain symbol such as `BRCA1` must
+ * never reach one, because the 400 fails the whole request.
+ */
 export function isUniProtAccession(query: string): boolean {
     return ACCESSION_RE.test(query.trim());
+}
+
+/**
+ * Build the UniProtKB query.
+ *
+ * The organism filter and the reviewed filter narrow an ambiguous SYMBOL
+ * search. An accession is a unique key, thus the filters must not reach it: a
+ * lookup of `P02769` under the human default would otherwise answer nothing,
+ * although the accession names bovine serum albumin.
+ *
+ * An accession-shaped input is ambiguous, because the two identifier spaces
+ * overlap. Such an input searches both, and the unfiltered accession clause is
+ * OR-ed with the filtered symbol clause. An input that is not
+ * accession-shaped searches the symbol space alone.
+ */
+function buildSearchQuery(query: string, organismId: number | undefined, reviewedOnly: boolean): string {
+    const symbolClauses = [`gene_exact:${query}`];
+    if (organismId !== undefined) symbolClauses.push(`organism_id:${organismId}`);
+    if (reviewedOnly) symbolClauses.push("reviewed:true");
+    const symbolQuery = symbolClauses.join(" AND ");
+
+    if (!isUniProtAccession(query)) return symbolQuery;
+    return `(accession:${query} OR (${symbolQuery}))`;
 }
 
 export interface SearchProteinsOptions {
@@ -283,12 +329,8 @@ export async function searchProteins(query: string, opts: SearchProteinsOptions 
     const { organismId, reviewedOnly = true, limit = 10 } = opts;
     const trimmed = query.trim();
 
-    const clauses = [isUniProtAccession(trimmed) ? `accession:${trimmed}` : `gene_exact:${trimmed}`];
-    if (organismId !== undefined) clauses.push(`organism_id:${organismId}`);
-    if (reviewedOnly) clauses.push("reviewed:true");
-
     const params = new URLSearchParams({
-        query: clauses.join(" AND "),
+        query: buildSearchQuery(trimmed, organismId, reviewedOnly),
         fields: SEARCH_FIELDS,
         format: "json",
         size: String(limit + 1),

--- a/harness/src/tools/lib/uniprot-search.fixtures.test.ts
+++ b/harness/src/tools/lib/uniprot-search.fixtures.test.ts
@@ -1,0 +1,40 @@
+import { expect } from "bun:test";
+
+import { fixtureCase, runFixtureSuite } from "./__fixtures__/fixture-runner.js";
+import { UniProtSearchResponseSchema } from "./uniprot-client.js";
+
+runFixtureSuite("UniProtKB search golden fixtures", [
+    fixtureCase({
+        name: "UniProtSearchResponseSchema (a curated entry, gene_exact + reviewed)",
+        provider: "uniprot",
+        fixture: "search_BRCA1_reviewed.json",
+        drift: "search_BRCA1_reviewed.drift.json",
+        schema: UniProtSearchResponseSchema,
+        assertOutput: (response) => {
+            const row = response.results![0]!;
+            expect(row.primaryAccession).toBe("P38398");
+            expect(row.uniProtkbId).toBe("BRCA1_HUMAN");
+            expect(row.entryType).toContain("reviewed");
+            expect(row.sequence?.length).toBe(1863);
+            expect(row.proteinDescription?.recommendedName?.fullName?.value).toBe("Breast cancer type 1 susceptibility protein");
+            // UniProt splits the locations over more than one comment, thus the
+            // mapper collects across every one of them.
+            const locationComments = (row.comments ?? []).filter((comment) => comment.commentType === "SUBCELLULAR LOCATION");
+            expect(locationComments.length).toBeGreaterThan(1);
+        },
+    }),
+    fixtureCase({
+        name: "UniProtSearchResponseSchema (an entry that omits the genes and the comments)",
+        provider: "uniprot",
+        fixture: "search_Q6ZQY7_sparse.json",
+        drift: "search_Q6ZQY7_sparse.drift.json",
+        schema: UniProtSearchResponseSchema,
+        assertOutput: (response) => {
+            const row = response.results![0]!;
+            expect(row.primaryAccession).toBe("Q6ZQY7");
+            // UniProt omits the key of an absent value, and it never sends null.
+            expect(row.genes).toBeUndefined();
+            expect(row.comments).toBeUndefined();
+        },
+    }),
+]);

--- a/harness/src/tools/lib/uniprot-search.fixtures.test.ts
+++ b/harness/src/tools/lib/uniprot-search.fixtures.test.ts
@@ -14,13 +14,30 @@ runFixtureSuite("UniProtKB search golden fixtures", [
             const row = response.results![0]!;
             expect(row.primaryAccession).toBe("P38398");
             expect(row.uniProtkbId).toBe("BRCA1_HUMAN");
-            expect(row.entryType).toContain("reviewed");
+            // The exact string, not `toContain("reviewed")` — the unreviewed
+            // value holds the reviewed one as a substring.
+            expect(row.entryType).toBe("UniProtKB reviewed (Swiss-Prot)");
             expect(row.sequence?.length).toBe(1863);
             expect(row.proteinDescription?.recommendedName?.fullName?.value).toBe("Breast cancer type 1 susceptibility protein");
             // UniProt splits the locations over more than one comment, thus the
             // mapper collects across every one of them.
             const locationComments = (row.comments ?? []).filter((comment) => comment.commentType === "SUBCELLULAR LOCATION");
             expect(locationComments.length).toBeGreaterThan(1);
+        },
+    }),
+    fixtureCase({
+        name: "UniProtSearchResponseSchema (a TrEMBL entry that carries submissionNames)",
+        provider: "uniprot",
+        fixture: "search_X5D778_trembl.json",
+        drift: "search_X5D778_trembl.drift.json",
+        schema: UniProtSearchResponseSchema,
+        assertOutput: (response) => {
+            const row = response.results![0]!;
+            expect(row.primaryAccession).toBe("X5D778");
+            expect(row.entryType).toBe("UniProtKB unreviewed (TrEMBL)");
+            // A TrEMBL row can name the protein in `submissionNames` alone.
+            expect(row.proteinDescription?.recommendedName).toBeUndefined();
+            expect(row.proteinDescription?.submissionNames?.[0]?.fullName?.value).toBe("Ankyrin repeat domain 11 isoform A");
         },
     }),
     fixtureCase({

--- a/harness/src/tools/research/literature-reviewer.test.ts
+++ b/harness/src/tools/research/literature-reviewer.test.ts
@@ -57,6 +57,7 @@ describe("literatureReviewer sub-agent tool", () => {
             "resolve_citation",
             "search_gene",
             "search_interactions",
+            "search_protein",
         ]);
 
         // The child transcript is not exposed — only the report leaves the tool.

--- a/harness/src/tools/research/literature-reviewer.ts
+++ b/harness/src/tools/research/literature-reviewer.ts
@@ -30,6 +30,7 @@ import { createChemDbTools, createNcbiTools, type BioToolKeys } from "../bio/key
 import { genePreclinicalProfileTool } from "../bio/gene-preclinical-profile.js";
 import { lookupAnnotationTool } from "../bio/lookup-annotation.js";
 import { searchGeneTool } from "../bio/search-gene.js";
+import { searchProteinTool } from "../bio/search-protein.js";
 import { searchInteractionsTool } from "../bio/search-interactions.js";
 import type { Logger } from "../../lib/logger.js";
 import type { UsageRecorder } from "../../billing/usage-recorder.js";
@@ -63,6 +64,7 @@ export function createLiteratureReviewerTool(deps: LiteratureReviewerDeps): Tool
     const chemDb = createChemDbTools(deps.bioKeys, { ...(deps.logger ? { logger: deps.logger } : {}) });
     const reviewerTools: readonly Tool[] = [
         searchGeneTool,
+        searchProteinTool,
         lookupAnnotationTool,
         searchInteractionsTool,
         ncbi.pubmed,


### PR DESCRIPTION
## What & why

add a tool for the harness to look up a protein in uniprotkb. before this, no agent could look up a protein directly - search_gene only returns ensembl gene records, not the protein itself. the tool takes a gene symbol or a uniprot accession and returns the protein name, gene names, sequence length, curated function, and subcellular locations. wired into the conversation agent and the literature reviewer.

<img width="1708" height="897" alt="image" src="https://github.com/user-attachments/assets/36ed4a09-0de3-4cfe-bae7-ba1bdf85c64d" />



Closes #59

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow Conventional Commits.
- [x] Commits are signed off for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

not applicable, this change adds a data-lookup tool only, no sandbox, method, or provenance change.

- [ ] Methods: the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] Sandbox: the security model is preserved (unprivileged uid-1000 workload, all capabilities dropped, no-new-privileges; no network egress in poll mode — the in-container firewall on Docker, a NetworkPolicy on K8s; signature-authenticated exec endpoints; read-only analysis tree with writes confined to the step's output directory; resource limits; and no host credentials in spawned commands); any loosening is called out and justified.
- [ ] Provenance: prior analyses remain reproducible (or the expected variance is documented).
