### PR TITLE
feat(harness): count the outcome of each sandbox exec

### DIFF
--- a/harness/src/lib/metrics.test.ts
+++ b/harness/src/lib/metrics.test.ts
@@ -5,7 +5,7 @@
  * registers the provider, so the instruments must bind at record time.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
 import { metrics } from "@opentelemetry/api";
 import { AggregationTemporality, InMemoryMetricExporter, MeterProvider, type MetricData, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 
@@ -17,6 +17,7 @@ import {
     recordArtifactReconcileDropped,
     recordLineageInputDropped,
     recordRunCompleted,
+    recordSandboxExec,
     recordStepCompleted,
     stepOutcomeOf,
 } from "./metrics.js";
@@ -106,6 +107,29 @@ describe("run and step outcome metrics", () => {
             // A ledger with no start gives no duration; a skipped step gives no outcome.
             expect(elapsedSinceIso(null)).toBeUndefined();
             expect(stepOutcomeOf("skipped")).toBeUndefined();
+        } finally {
+            await capture.dispose();
+        }
+    });
+});
+
+describe("sandbox exec metrics", () => {
+    test("a replayed exec adds one count and one duration sample, under the outcome label alone", async () => {
+        await provider.shutdown();
+        const capture = captureMetrics();
+        try {
+            recordSandboxExec({ execId: "wf-1:step-a:3", outcome: "nonzero", durationMs: 4_000 });
+            // The workflow body re-runs the await loop on recovery and reaches
+            // the record site again with the same exec id.
+            recordSandboxExec({ execId: "wf-1:step-a:3", outcome: "nonzero", durationMs: 4_000 });
+            // A synthetic failure carries no runtime, thus it counts without timing.
+            recordSandboxExec({ execId: "wf-1:step-a:4", outcome: "synthetic-oom", durationMs: null });
+
+            expect(await capture.sums("cortex.sandbox.execs")).toEqual([
+                [{ outcome: "nonzero" }, 1],
+                [{ outcome: "synthetic-oom" }, 1],
+            ]);
+            expect(await capture.histograms("cortex.sandbox.exec.duration")).toEqual([[{ outcome: "nonzero" }, { count: 1, sum: 4_000 }]]);
         } finally {
             await capture.dispose();
         }

--- a/harness/src/lib/metrics.ts
+++ b/harness/src/lib/metrics.ts
@@ -6,18 +6,23 @@
  *   - cortex.run.duration{status, workflow}       — histogram, start to terminal status
  *   - cortex.step.completed{status, agent_id}     — counter, one per executed step that settled
  *   - cortex.step.duration{status, agent_id}      — histogram, step start to its terminal ledger write
+ *   - cortex.sandbox.execs{outcome}               — counter, one per sandbox exec that returned a terminal result
+ *   - cortex.sandbox.exec.duration{outcome}       — histogram, the runtime the sandbox reported for that exec
  *   - cortex.artifact.reconcile.dropped{agent_id}              — counter for missing manifest entries
  *   - cortex.artifact.reconcile.input_dropped{agent_id, reason} — counter for lineage input drops
  *
  * Every label is a bounded vocabulary: `status` is the terminal enum, `workflow`
- * names the workflow family, `agent_id` has about 15 values. No instrument
- * carries a run, step, exec, user, or organization id — a label with unbounded
- * values multiplies the series count.
+ * names the workflow family, `agent_id` has about 15 values, `outcome` has
+ * five. No instrument carries a run, step, exec, user, or organization id — a
+ * label with unbounded values multiplies the series count, and the collector
+ * drops a datapoint that carries one.
  *
  * A run or step outcome is recorded INSIDE the DBOS step that persists the same
  * outcome to the ledger (or behind the ledger's own compare-and-set where the
  * body has no such step). DBOS caches a completed step and does not re-run its
- * body on recovery, so a replayed workflow records nothing twice.
+ * body on recovery, so a replayed workflow records nothing twice. An exec has
+ * no such step, so `recordSandboxExec` carries its own idempotence — see the
+ * note on `countedExecs`.
  *
  * Instruments are lazy so the record site binds to whichever `MeterProvider`
  * is globally registered at first use. The metrics API has no late-binding
@@ -39,17 +44,34 @@ export type RunWorkflow = "analysis" | "target_assessment" | "data_profile";
 export type StepOutcome = "completed" | "failed" | "canceled";
 
 /**
+ * Terminal outcome of one sandbox exec. `nonzero` is the command's own
+ * verdict; `timeout` is the deadline; the two synthetic values name a machine
+ * that died under the command, which is an outcome of the platform and not of
+ * the analysis. Five values, thus five series for each instrument.
+ */
+export type SandboxExecOutcome = "ok" | "nonzero" | "timeout" | "synthetic-dead" | "synthetic-oom";
+
+/**
  * Bucket bounds for durations that run from seconds to hours: 30 s, then
  * 1, 2, 5, 10, 30, 60, 120, 240 min. Ten buckets with the overflow, so one
  * histogram costs about ten series per label set.
  */
 export const RUN_DURATION_BOUNDS_MS: readonly number[] = [30_000, 60_000, 120_000, 300_000, 600_000, 1_800_000, 3_600_000, 7_200_000, 14_400_000];
 
+/**
+ * Bucket bounds for one exec, which runs from a sub-second probe to an
+ * hours-long analysis: 1, 5, 15, 30 s, then 1, 5, 15, 30, 60 min. The run
+ * bounds start at 30 s and would put almost every exec in the first bucket.
+ */
+export const EXEC_DURATION_BOUNDS_MS: readonly number[] = [1_000, 5_000, 15_000, 30_000, 60_000, 300_000, 900_000, 1_800_000, 3_600_000];
+
 interface Instruments {
     readonly runCompleted: Counter;
     readonly runDuration: Histogram;
     readonly stepCompleted: Counter;
     readonly stepDuration: Histogram;
+    readonly sandboxExecs: Counter;
+    readonly sandboxExecDuration: Histogram;
     readonly artifactReconcileDropped: Counter;
     readonly lineageInputDropped: Counter;
 }
@@ -78,6 +100,15 @@ function getInstruments(): Instruments {
                 description: "Step duration from its start to its terminal ledger write. Tagged by status, agent_id.",
                 unit: "ms",
                 advice,
+            }),
+            sandboxExecs: meter.createCounter("cortex.sandbox.execs", {
+                description: "Sandbox execs that returned a terminal result. Tagged by outcome.",
+                unit: "{exec}",
+            }),
+            sandboxExecDuration: meter.createHistogram("cortex.sandbox.exec.duration", {
+                description: "Runtime the sandbox reported for one exec. Tagged by outcome.",
+                unit: "ms",
+                advice: { explicitBucketBoundaries: [...EXEC_DURATION_BOUNDS_MS] },
             }),
             artifactReconcileDropped: meter.createCounter("cortex.artifact.reconcile.dropped", {
                 description:
@@ -159,6 +190,45 @@ export function elapsedSinceIso(startedAt: string | null | undefined, nowMs: num
     return Math.max(0, nowMs - startedMs);
 }
 
+/**
+ * Exec ids already counted, so a replay counts one exec one time.
+ *
+ * The run and step counters sit inside the DBOS step that persists the same
+ * outcome, and DBOS never runs a cached step body a second time. An exec has
+ * no such step: `awaitExec` returns into the workflow body, and a new step
+ * around the record would shift the function-id sequence of every workflow
+ * that is already in flight. An exec id is `{workflowId}:{stepId}:{functionId}`
+ * and it is stable across a replay, thus it is the key that makes the record
+ * idempotent. The set is process-local: a recovery in a fresh process holds no
+ * memory of the first count and can count that exec again.
+ */
+const countedExecs = new Set<string>();
+
+/**
+ * How many exec ids the guard remembers. A host runs far fewer concurrent
+ * execs than this, and a replay follows its original within one run, thus the
+ * cap only drops an id that no live workflow can present again.
+ */
+const MAX_COUNTED_EXECS = 4096;
+
+/**
+ * Record one sandbox exec that returned a terminal result. Call it at the one
+ * seam where an `ExecResult` crosses from the wire into the process. A result
+ * that carries no runtime (a synthetic failure) is counted, not timed.
+ */
+export function recordSandboxExec(args: { readonly execId: string; readonly outcome: SandboxExecOutcome; readonly durationMs?: number | null }): void {
+    if (countedExecs.has(args.execId)) return;
+    if (countedExecs.size >= MAX_COUNTED_EXECS) {
+        const oldest = countedExecs.values().next();
+        if (!oldest.done) countedExecs.delete(oldest.value);
+    }
+    countedExecs.add(args.execId);
+    const attributes = { outcome: args.outcome };
+    const { sandboxExecs, sandboxExecDuration } = getInstruments();
+    sandboxExecs.add(1, attributes);
+    if (args.durationMs !== undefined && args.durationMs !== null) sandboxExecDuration.record(Math.max(0, args.durationMs), attributes);
+}
+
 /** Record one manifest entry dropped at reconcile. */
 export function recordArtifactReconcileDropped(args: { readonly agentId: string }): void {
     getInstruments().artifactReconcileDropped.add(1, { agent_id: args.agentId });
@@ -174,4 +244,5 @@ export function recordLineageInputDropped(args: { readonly agentId: string; read
 /** Test hook — drop memoised instruments to rebind a fresh MeterProvider. */
 export function __resetMetricsForTest(): void {
     instruments = undefined;
+    countedExecs.clear();
 }

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -19,6 +19,7 @@ import type { V1Toleration } from "@kubernetes/client-node";
 import type { Pool } from "pg";
 
 import type { Logger } from "../lib/logger.js";
+import { recordSandboxExec } from "../lib/metrics.js";
 import { clampResources, type ResourceLimits } from "../config/resource-limits.js";
 import { tailWritePrefix, type ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { tryMutation } from "../lib/db-result.js";
@@ -28,6 +29,7 @@ import { capExecStreams, EXEC_STREAM_BYTE_CAP } from "../tools/workspace/result-
 import { awaitExec, type AwaitExecOptions } from "./await-exec.js";
 import type { SandboxClient } from "./client.js";
 import { createDockerSandboxOps } from "./docker-client.js";
+import { noteExecOutcome, sandboxExecOutcomeOf, summarizeExec } from "./exec-outcome.js";
 import { createK8sSandboxOps } from "./k8s-client.js";
 import { sandboxWriteTail } from "./mount-plan.js";
 import { SandboxFailure, type SandboxError } from "./sandbox-error.js";
@@ -366,11 +368,22 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
         // tool results, workflow return values, durable step outputs — is bounded
         // by construction, including against a sandbox image that predates the
         // retention budget and still returns whole streams.
-        awaitExec: async (ref, execId, emit, deadline) =>
-            capExecStreams(
+        //
+        // The same seam is where an exec becomes observable. It sees every exec
+        // of every caller — the step agent, the data profile, the derivations —
+        // and it sees the outcome the caller then folds into a tool result, so
+        // one record here counts what a consumer would each have to count for
+        // itself. `recordSandboxExec` is idempotent over the exec id, because a
+        // replayed body reaches this line again.
+        awaitExec: async (ref, execId, emit, deadline) => {
+            const result = capExecStreams(
                 await awaitExec(ref, execId, emit, deadline, composeAwaitOptions(config.awaitOptions, transport, isAlive)),
                 config.execStreamByteCap ?? EXEC_STREAM_BYTE_CAP,
-            ),
+            );
+            recordSandboxExec({ execId, outcome: sandboxExecOutcomeOf(result), durationMs: result.durationMs });
+            noteExecOutcome(ref.sandboxId, summarizeExec(result));
+            return result;
+        },
         isAlive,
         isAliveById: async (sandboxId) => unwrapOrThrow((await ops.isAliveById(sandboxId)).mapErr(failing)),
         teardown,

--- a/harness/src/sandbox/exec-outcome.test.ts
+++ b/harness/src/sandbox/exec-outcome.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The exec outcome vocabulary and the text-free summary the step-failure
+ * record carries.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { lastExecOutcome, noteExecOutcome, sandboxExecOutcomeOf, summarizeExec } from "./exec-outcome.js";
+import type { ExecResult } from "./types.js";
+
+function execResult(over: Partial<ExecResult>): ExecResult {
+    return { execId: "wf:step:1", exitCode: 0, stdout: "", stderr: "", durationMs: 10, timedOut: false, ...over };
+}
+
+describe("sandboxExecOutcomeOf", () => {
+    test("a dead machine outranks the exit code and the timeout the kill left behind", () => {
+        const outcomes = [
+            sandboxExecOutcomeOf(execResult({})),
+            sandboxExecOutcomeOf(execResult({ exitCode: 2 })),
+            sandboxExecOutcomeOf(execResult({ exitCode: null })),
+            sandboxExecOutcomeOf(execResult({ exitCode: 124, timedOut: true })),
+            sandboxExecOutcomeOf(execResult({ exitCode: null, timedOut: true, syntheticFailure: { reason: "sandbox-dead" } })),
+            sandboxExecOutcomeOf(execResult({ exitCode: 137, timedOut: true, syntheticFailure: { reason: "sandbox-oom-killed" } })),
+        ];
+        expect(outcomes).toEqual(["ok", "nonzero", "nonzero", "timeout", "synthetic-dead", "synthetic-oom"]);
+    });
+});
+
+describe("summarizeExec", () => {
+    test("gives the size of stderr and none of its text", () => {
+        const summary = summarizeExec(execResult({ exitCode: 1, stderr: "Traceback: /srv/secrets/key.pem is unreadable" }));
+
+        expect(summary).toEqual({ exitCode: 1, timedOut: false, stderrTotalBytes: 45 });
+        expect(JSON.stringify(summary)).not.toContain("Traceback");
+    });
+
+    test("keeps the total the sandbox reported when it dropped output at the producer", () => {
+        const summary = summarizeExec(execResult({ exitCode: 1, stderr: "kept slice", stderrTotalBytes: 9_000_000 }));
+
+        expect(summary.stderrTotalBytes).toBe(9_000_000);
+    });
+});
+
+describe("the last exec of a sandbox", () => {
+    test("is the one the step body reads back, per sandbox", () => {
+        noteExecOutcome("sbx-a", summarizeExec(execResult({ exitCode: 0 })));
+        noteExecOutcome("sbx-a", summarizeExec(execResult({ exitCode: 3, stderr: "x" })));
+        noteExecOutcome("sbx-b", summarizeExec(execResult({ exitCode: null, syntheticFailure: { reason: "sandbox-oom-killed" } })));
+
+        expect(lastExecOutcome("sbx-a")).toEqual({ exitCode: 3, timedOut: false, stderrTotalBytes: 1 });
+        expect(lastExecOutcome("sbx-b")).toEqual({ exitCode: null, timedOut: false, stderrTotalBytes: 0, syntheticFailureReason: "sandbox-oom-killed" });
+        expect(lastExecOutcome("sbx-never-ran")).toBeUndefined();
+    });
+});

--- a/harness/src/sandbox/exec-outcome.ts
+++ b/harness/src/sandbox/exec-outcome.ts
@@ -1,0 +1,86 @@
+/**
+ * What one settled exec is worth to an operator: the bounded outcome that
+ * `cortex.sandbox.execs` counts, and the summary that the `step failure`
+ * record of `workflows/sandbox-step.ts` carries.
+ *
+ * No stream text crosses this module. Sandbox output is generated code and the
+ * output of that code, thus it is untrusted, and the sandbox-exec-logging spec
+ * keeps that text on the sandbox side of the boundary. A summary gives the
+ * SIZE of stderr and never a byte of it.
+ *
+ * The summary of the last exec of a sandbox lives in one process-local cell,
+ * keyed by sandbox id. A sandbox belongs to one step (see the teardown of
+ * `create-sandbox.ts`), thus the cell is step-scoped in effect and the step
+ * body reads it without a new dependency through the agent factory. A replay
+ * re-runs the await loop and writes the cell again, thus a recovered body
+ * reads the summary of the same exec. The map is capped, so a sandbox whose
+ * step never reaches the read site cannot hold memory.
+ */
+
+import type { SandboxExecOutcome } from "../lib/metrics.js";
+import type { SyntheticFailureReason } from "./liveness.js";
+import type { ExecResult } from "./types.js";
+
+/** The reason that names a machine the kernel killed for its memory limit. */
+const OOM_KILLED: SyntheticFailureReason = "sandbox-oom-killed";
+
+/**
+ * The outcome one result carries. A synthetic failure names a dead machine and
+ * not a command, thus it wins over every other field. A timeout wins over the
+ * exit code that the kill produced. `ok` is exit code 0 and nothing else, thus
+ * a result with no code counts as `nonzero`.
+ */
+export function sandboxExecOutcomeOf(result: ExecResult): SandboxExecOutcome {
+    if (result.syntheticFailure) return result.syntheticFailure.reason === OOM_KILLED ? "synthetic-oom" : "synthetic-dead";
+    if (result.timedOut) return "timeout";
+    return result.exitCode === 0 ? "ok" : "nonzero";
+}
+
+/** The account of one exec that a failure record can hold. Text-free by construction. */
+export interface ExecOutcomeSummary {
+    readonly exitCode: number | null;
+    readonly timedOut: boolean;
+    /**
+     * What the command wrote to stderr, in bytes. The sandbox reports the total
+     * when it dropped output past its retention budget; without that total the
+     * retained slice IS the whole stream, so its length is the total.
+     */
+    readonly stderrTotalBytes: number;
+    readonly syntheticFailureReason?: string;
+}
+
+/** Reduce a result to its summary. */
+export function summarizeExec(result: ExecResult): ExecOutcomeSummary {
+    return {
+        exitCode: result.exitCode,
+        timedOut: result.timedOut,
+        stderrTotalBytes: result.stderrTotalBytes ?? Buffer.byteLength(result.stderr, "utf8"),
+        ...(result.syntheticFailure ? { syntheticFailureReason: result.syntheticFailure.reason } : {}),
+    };
+}
+
+/**
+ * How many sandboxes keep a summary. A host runs far fewer sandboxes at once
+ * than this, thus the cap only drops the summary of a step that ended long ago.
+ */
+const MAX_TRACKED_SANDBOXES = 256;
+
+const lastExecBySandbox = new Map<string, ExecOutcomeSummary>();
+
+/** Keep `summary` as the last known exec of `sandboxId`. */
+export function noteExecOutcome(sandboxId: string, summary: ExecOutcomeSummary): void {
+    // Delete before set so the key moves to the end of the insertion order and
+    // the eviction below drops the least recently written sandbox.
+    lastExecBySandbox.delete(sandboxId);
+    lastExecBySandbox.set(sandboxId, summary);
+    while (lastExecBySandbox.size > MAX_TRACKED_SANDBOXES) {
+        const oldest = lastExecBySandbox.keys().next();
+        if (oldest.done) break;
+        lastExecBySandbox.delete(oldest.value);
+    }
+}
+
+/** The last known exec of `sandboxId`, or `undefined` when it ran none. */
+export function lastExecOutcome(sandboxId: string): ExecOutcomeSummary | undefined {
+    return lastExecBySandbox.get(sandboxId);
+}

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -11,7 +11,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { BatchV1Api, CoreV1Api, V1Job, V1Pod } from "@kubernetes/client-node";
 
-import { createK8sSandboxOps, sanitizeLabelValue } from "./k8s-client.js";
+import { createCapturingLogger } from "../__tests__/setup/logger.js";
+import { createK8sSandboxOps, sanitizeLabelValue, waitForPodReady } from "./k8s-client.js";
 import { mintSandboxIdentity } from "./identity.js";
 import type { FarmSource } from "./types.js";
 
@@ -1254,5 +1255,57 @@ describe("k8s createSandbox — the farm mounts", () => {
         };
         await expect(attempt()).rejects.toThrow(/PVC-relative/);
         expect(stub.createdJobs).toHaveLength(0);
+    });
+});
+
+describe("k8s waitForPodReady — the slow pod", () => {
+    /** A pod list that answers with `pod` every time, and a clock the sleep advances. */
+    function pendingPod(pod: Partial<V1Pod>) {
+        let clock = 0;
+        const coreApi = {
+            listNamespacedPod: async () => ({ items: [pod as V1Pod] }),
+        } as unknown as CoreV1Api;
+        return {
+            coreApi,
+            now: () => clock,
+            sleep: async (ms: number) => {
+                clock += ms;
+            },
+        };
+    }
+
+    test("warns once past a minute, naming the condition the pod waits on", async () => {
+        const clockedApi = pendingPod({
+            status: { phase: "Pending", conditions: [{ type: "PodScheduled", status: "False", reason: "Unschedulable", lastTransitionTime: new Date() }] },
+            metadata: { name: "sbx-slow" },
+        });
+        const logger = createCapturingLogger();
+
+        const result = await waitForPodReady(clockedApi.coreApi, "sandbox", "sbx-slow", {
+            logger,
+            now: clockedApi.now,
+            sleep: clockedApi.sleep,
+        });
+
+        expect(result.isErr()).toBe(true);
+        const warnings = logger.records.filter((r) => r.level === "warn");
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]!.msg).toBe("[k8s-client] sandbox pod is slow to reach Running");
+        expect(warnings[0]!.fields).toMatchObject({ sandboxId: "sbx-slow", phase: "Pending", conditionReason: "Unschedulable" });
+        expect(warnings[0]!.fields.waitedMs as number).toBeGreaterThanOrEqual(60_000);
+    });
+
+    test("says nothing about a pod that comes up inside the minute", async () => {
+        const clockedApi = pendingPod({ status: { phase: "Running", podIP: "10.0.0.9" }, metadata: { name: "sbx-fast" } });
+        const logger = createCapturingLogger();
+
+        const result = await waitForPodReady(clockedApi.coreApi, "sandbox", "sbx-fast", {
+            logger,
+            now: clockedApi.now,
+            sleep: clockedApi.sleep,
+        });
+
+        expect(result._unsafeUnwrap()).toEqual({ podIP: "10.0.0.9", podName: "sbx-fast" });
+        expect(logger.records).toEqual([]);
     });
 });

--- a/harness/src/sandbox/k8s-client.ts
+++ b/harness/src/sandbox/k8s-client.ts
@@ -21,6 +21,7 @@ import {
     KubeConfig,
     type V1Job,
     type V1ObjectMeta,
+    type V1Pod,
     type V1PodSpec,
     type V1Toleration,
     type V1Volume,
@@ -59,6 +60,13 @@ const REFS_VOLUME_NAME = "refs";
 const SANDBOX_SERVER_PORT = 8765;
 const POD_READY_TIMEOUT_MS = 5 * 60_000;
 const POD_POLL_INTERVAL_MS = 1_000;
+/**
+ * How long a pod can take to reach Running before the wait is worth a warning.
+ * A sandbox pod on a warm agent node starts in seconds; a minute means the
+ * scheduler is waiting for something — a node to come up, a quota, a volume —
+ * and the run pays that minute before any command executes.
+ */
+const POD_READY_SLOW_MS = 60_000;
 
 const MANAGED_BY_LABEL = "app.kubernetes.io/managed-by";
 const MANAGED_BY_VALUE = "cortex";
@@ -436,9 +444,32 @@ interface PodStatusSnapshot {
     phase?: string;
     podIP?: string;
     podName?: string;
+    /** Why the pod is not there yet — `Unschedulable`, `ContainersNotReady`, and the rest. */
+    reason?: string;
 }
 
-function waitForPodReady(coreApi: CoreV1Api, namespace: string, sandboxId: string): ResultAsync<{ podIP: string; podName: string }, SandboxError> {
+/**
+ * The reason of the first condition the pod does not meet. `PodScheduled` and
+ * `Ready` both carry one, and it names what the wait is actually on.
+ */
+function pendingConditionReason(pod: V1Pod | undefined): string | undefined {
+    const unmet = pod?.status?.conditions?.find((condition) => condition.status !== "True" && (condition.reason ?? "") !== "");
+    return unmet?.reason;
+}
+
+/** Clock and sleep seams, so a test can drive the slow-pod warning without waiting a minute. */
+export interface WaitForPodReadyDeps {
+    readonly logger?: Logger;
+    readonly now?: () => number;
+    readonly sleep?: (ms: number) => Promise<void>;
+}
+
+export function waitForPodReady(
+    coreApi: CoreV1Api,
+    namespace: string,
+    sandboxId: string,
+    deps: WaitForPodReadyDeps = {},
+): ResultAsync<{ podIP: string; podName: string }, SandboxError> {
     const createFailed = (status: number | undefined, cause: unknown): SandboxError => ({
         type: "container_create_failed",
         op: "k8s.waitForPodReady",
@@ -446,11 +477,16 @@ function waitForPodReady(coreApi: CoreV1Api, namespace: string, sandboxId: strin
         status,
         cause,
     });
+    const now = deps.now ?? (() => Date.now());
+    const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+    const logger = (deps.logger ?? createNoopLogger()).named("k8s-client");
     return new ResultAsync(
         (async () => {
-            const deadline = Date.now() + POD_READY_TIMEOUT_MS;
+            const startedAt = now();
+            const deadline = startedAt + POD_READY_TIMEOUT_MS;
+            let warnedSlow = false;
             let lastSnapshot: PodStatusSnapshot = {};
-            while (Date.now() < deadline) {
+            while (now() < deadline) {
                 const listed = await trySandbox(
                     () =>
                         coreApi.listNamespacedPod({
@@ -465,6 +501,7 @@ function waitForPodReady(coreApi: CoreV1Api, namespace: string, sandboxId: strin
                     phase: pod?.status?.phase,
                     podIP: pod?.status?.podIP,
                     podName: pod?.metadata?.name,
+                    reason: pendingConditionReason(pod),
                 };
                 if (pod && pod.status?.phase === "Running" && typeof pod.status.podIP === "string" && pod.metadata?.name) {
                     return ok({ podIP: pod.status.podIP, podName: pod.metadata.name });
@@ -472,7 +509,21 @@ function waitForPodReady(coreApi: CoreV1Api, namespace: string, sandboxId: strin
                 if (pod?.status?.phase === "Failed") {
                     return err(createFailed(undefined, new Error(`K8sSandbox ${sandboxId}: pod phase=Failed before becoming ready`)));
                 }
-                await new Promise((r) => setTimeout(r, POD_POLL_INTERVAL_MS));
+                // One warning for one wait: the pod is still pending a minute in, and
+                // the condition reason says what it waits on. The timeout error
+                // below reports the five-minute give-up.
+                const waitedMs = now() - startedAt;
+                if (!warnedSlow && waitedMs >= POD_READY_SLOW_MS) {
+                    warnedSlow = true;
+                    logger.warn("sandbox pod is slow to reach Running", {
+                        sandboxId,
+                        namespace,
+                        waitedMs,
+                        phase: lastSnapshot.phase ?? null,
+                        conditionReason: lastSnapshot.reason ?? null,
+                    });
+                }
+                await sleep(POD_POLL_INTERVAL_MS);
             }
             return err(
                 createFailed(
@@ -672,7 +723,7 @@ export function createK8sSandboxOps(config: K8sClientConfig): {
                     // finishes) — the Job controller retries pod creation forever. Delete
                     // the Job on any startup failure so a failed create can't leak a
                     // zombie that floods k8s events indefinitely.
-                    const ready = await waitForPodReady(coreApi, config.namespace, sandboxId);
+                    const ready = await waitForPodReady(coreApi, config.namespace, sandboxId, { ...(config.logger ? { logger: config.logger } : {}) });
                     if (ready.isOk()) {
                         const ref: SandboxRef = {
                             sandboxId,

--- a/harness/src/sandbox/liveness.ts
+++ b/harness/src/sandbox/liveness.ts
@@ -73,11 +73,14 @@ export async function probeLiveness(isAlive: (ref: SandboxRef) => Promise<Sandbo
     return liveness.alive ? { kind: "alive" } : { kind: "dead", oomKilled: liveness.oomKilled };
 }
 
+/** The closed set of reasons a synthetic failure carries. */
+export type SyntheticFailureReason = "sandbox-oom-killed" | "sandbox-dead";
+
 /**
  * An OOM-killed machine gets a distinguishable reason so the step failure
  * reads "exceeded its memory limit", not a mystery death.
  */
-export function syntheticFailureReason(liveness: Pick<SandboxLiveness, "oomKilled">): "sandbox-oom-killed" | "sandbox-dead" {
+export function syntheticFailureReason(liveness: Pick<SandboxLiveness, "oomKilled">): SyntheticFailureReason {
     return liveness.oomKilled ? "sandbox-oom-killed" : "sandbox-dead";
 }
 

--- a/harness/src/workflows/sandbox-step.ts
+++ b/harness/src/workflows/sandbox-step.ts
@@ -43,6 +43,7 @@ import { isBudgetExceeded } from "../loop/budget-exceeded.js";
 import type { AgentDefinition, EmitFn, LoopMessage } from "../loop/types.js";
 import { runAgent } from "../loop/run-agent.js";
 import { durableStep } from "../loop/run-step.js";
+import { lastExecOutcome } from "../sandbox/exec-outcome.js";
 import { activityForTool, applyTreeDelta, isChatDataPart, sandboxTreeDelta, stepPartId } from "../sandbox/sandbox-step-translate.js";
 import { createDetailResolver } from "../tools/detail-resolver.js";
 import type { AgentChat, EmbeddingProvider } from "../providers/types.js";
@@ -567,8 +568,15 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
         // The scrub below is deliberate and load-bearing, which makes this record
         // the ONLY account of why the step died — the thrown error carries just the
         // generic phrase, so nothing downstream can reconstruct the cause.
+        // `durationMs`, the iteration cap, and the last exec of the sandbox are
+        // what separate a step that died in the model from one that died in the
+        // machine. `lastExec` holds no stream text (see `exec-outcome.ts`).
+        const lastExec = lastExecOutcome(sandbox.sandboxId);
         logger.error("step failure", {
             errorClass,
+            durationMs,
+            hitMaxSteps,
+            ...(lastExec ? { lastExec } : {}),
             ...logger.errorFields(err),
         });
         const safe = userFacingStepFailure(errorClass);
@@ -646,7 +654,8 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
 
     let transcript: LoopMessage[];
     let finishReason: string;
-    let hitMaxSteps: boolean;
+    // `false` until the loop reports otherwise: a loop that throws never reached its cap.
+    let hitMaxSteps = false;
     let stepUsage: TokenUsageRollup | undefined;
     try {
         const agentResult = await runAgent(agent, initial, session, {


### PR DESCRIPTION
## What & why

The one seam where an `ExecResult` crosses from the wire into the process
(`capExecStreams` in `createSandboxClient`) computed the outcome of an exec and
dropped it. From outside a run, a failed Job gave no reason. The seam now counts
each exec, and the `step failure` record carries what the last one did.

Notes for the review:

- **The labels.** `cortex.sandbox.execs{outcome}` and
  `cortex.sandbox.exec.duration{outcome}`, with `outcome` one of `ok`, `nonzero`,
  `timeout`, `synthetic-dead`, `synthetic-oom`. No id rides on either instrument.
- **The replay guard.** The run and step counters sit inside the DBOS step that
  persists the same outcome. An exec has no such step: `awaitExec` returns into
  the workflow body, and a new step around the record would move the function-id
  sequence of each workflow that is already in flight. `recordSandboxExec` is
  thus idempotent over the exec id, which is stable across a replay. The guard is
  process-local, so a recovery in a fresh process can count one exec a second
  time. Ask if a durable guard is worth a table.
- **No stream text.** The summary in `sandbox/exec-outcome.ts` gives the exit
  code, the timeout flag, the reason of a synthetic failure, and the SIZE of
  stderr. Sandbox output is generated code and its output, thus it stays on the
  sandbox side of the boundary (D-07 / D-16).
- **The last exec.** The summary lives in one process-local cell, keyed by
  sandbox id, and a sandbox belongs to one step. The step body thus reads it
  without a new dependency through the embedder's agent factory.
- **The pod warning.** `waitForPodReady` takes clock and sleep seams so a test
  drives the 60 s threshold without a real minute.

## Type of change

- [x] New feature / capability

## Checklist

- [x] Typecheck and tests pass locally (`bun run typecheck`, `bun test` — 4369 pass, 0 fail). `bun run lint` reports one error in `src/providers/ai-sdk.test.ts:1378`, which is present on `main` and which this branch does not touch.
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

https://claude.ai/code/session_016atnPmGMDtgjcKGuTyEFWV
