### PR TITLE
feat(harness): report stale DBOS workflows and their recovery attempts

### DIFF
--- a/harness/src/lib/otel.ts
+++ b/harness/src/lib/otel.ts
@@ -18,8 +18,10 @@
  *          outcome instruments (`cortex.run.*`, `cortex.step.*`) and the
  *          reconcile counters are defined in metrics.ts; the agent loop, the
  *          thread memory, and the workflows hold their own instruments next
- *          to their record sites. Every instrument binds lazily to the
- *          provider registered here.
+ *          to their record sites, and `runtime/dbos.ts` observes the DBOS
+ *          workflow table at each export. Every instrument binds to the
+ *          provider registered here: a record site at its first use, the
+ *          DBOS gauges at boot, after this init.
  *
  * Resource: the host's `serviceName` / `serviceVersion` merged with the SDK
  *           env detector (`OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`);

--- a/harness/src/runtime/boot.ts
+++ b/harness/src/runtime/boot.ts
@@ -25,6 +25,9 @@
  *      legacy-workflow reap, an agent-switch install). Runs after registration
  *      so it may close over the registered callables.
  *   7. `launchDbos(...)` — the last registration-dependent step.
+ *   8. `observeDbosWorkflows(...)` — the stuck-workflow gauges. They bind to
+ *      the meter that step 1 registered, and they read the schema that step 7
+ *      migrated. With no meter registered, nothing calls them and no query runs.
  *
  * No step reads or rewrites stored conversation display. A boot that validated
  * every `messages` row is what let a single retired part key fail startup for a
@@ -44,7 +47,7 @@ import { validateAgentSkills } from "../agents/sandbox/validate-skills.js";
 import { initCortexState } from "../state/init.js";
 import { assembleCoreRuntime, type CoreRuntime, type CoreRuntimeDeps } from "./assemble.js";
 import { assertConnectionBudget, type ConnectionBudgetConfig } from "./connection-budget.js";
-import { launchDbos, shutdownDbos, type DbosConfig } from "./dbos.js";
+import { launchDbos, observeDbosWorkflows, shutdownDbos, type DbosConfig } from "./dbos.js";
 import { markDraining } from "./lifecycle.js";
 import { runShutdownSequence } from "./shutdown.js";
 
@@ -106,6 +109,8 @@ export async function bootHarness(deps: BootHarnessDeps): Promise<BootedHarness>
     await deps.beforeLaunch?.();
 
     await launchDbos({ config: deps.dbos, logger });
+
+    observeDbosWorkflows({ pool, logger });
 
     logger.named("boot").info("harness booted", { executorId: deps.dbos.executorId });
 

--- a/harness/src/runtime/dbos.test.ts
+++ b/harness/src/runtime/dbos.test.ts
@@ -1,17 +1,28 @@
 /**
  * Unit tests for the DBOS bootstrap module. The actual DBOS engine is not
- * launched — these tests cover idempotence, state reporting, shutdown, and
- * the legacy pre-recovery migration sweep.
+ * launched — these tests cover idempotence, state reporting, shutdown, the
+ * legacy pre-recovery migration sweep, and the workflow health gauges.
  *
  * End-to-end "launch a real DBOS against a testcontainer" coverage lives
  * with the durable workflow tests (change 8).
  */
 
 import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { type Attributes, metrics } from "@opentelemetry/api";
+import { AggregationTemporality, type GaugeMetricData, InMemoryMetricExporter, MeterProvider, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import type { Pool } from "pg";
 
 import { createCapturingLogger, silentLogger } from "../__tests__/setup/logger.js";
-import { __resetDbosStateForTest, __setDbosStateForTest, dbosSdkConfig, dbosSdkLogger, dbosState, sweepEphemeralWorkflows, type DbosConfig } from "./dbos.js";
+import {
+    __resetDbosStateForTest,
+    __setDbosStateForTest,
+    dbosSdkConfig,
+    dbosSdkLogger,
+    dbosState,
+    observeDbosWorkflows,
+    sweepEphemeralWorkflows,
+    type DbosConfig,
+} from "./dbos.js";
 
 const stubConfig = {} as DbosConfig;
 
@@ -176,5 +187,101 @@ describe("legacy ephemeral workflow migration sweep", () => {
         expect(queries[0]!.text).toContain("executor_id = $2");
         expect(queries[0]!.text).toContain("workflow_uuid LIKE 'ephemeral:%'");
         expect(queries[0]!.values?.[1]).toBe("executor-1");
+    });
+});
+
+describe("workflow health gauges", () => {
+    let exporter: InMemoryMetricExporter;
+    let provider: MeterProvider;
+
+    beforeEach(() => {
+        exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+        provider = new MeterProvider({ readers: [new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 3_600_000 })] });
+    });
+
+    afterEach(async () => {
+        await provider.shutdown();
+        metrics.disable();
+    });
+
+    /** Run one collection and give the points of each gauge that it exported, by instrument name. */
+    async function collect(): Promise<Record<string, Array<[Attributes, number]>>> {
+        exporter.reset();
+        await provider.forceFlush();
+        const exported: Record<string, Array<[Attributes, number]>> = {};
+        for (const metric of exporter
+            .getMetrics()
+            .flatMap((rm) => rm.scopeMetrics)
+            .flatMap((sm) => sm.metrics)) {
+            const points = (metric as GaugeMetricData).dataPoints;
+            if (points.length > 0) exported[metric.descriptor.name] = points.map((point) => [point.attributes, point.value]);
+        }
+        return exported;
+    }
+
+    it("maps the grouped rows onto the gauges, and observes zero for a status that has no row", async () => {
+        metrics.setGlobalMeterProvider(provider);
+        __setDbosStateForTest({ launched: true });
+        // `pg` answers a message of two statements with one result for each, and a bigint as a string.
+        const answers = [
+            [{ rows: [] }, { rows: [{ status: "PENDING", stale: "2", max_recovery_attempts: "7" }] }],
+            [{ rows: [] }, { rows: [] }],
+        ];
+        const pool = { query: () => Promise.resolve(answers.shift()) } as unknown as Pool;
+        observeDbosWorkflows({ pool, logger: silentLogger });
+
+        expect(await collect()).toEqual({
+            "cortex.dbos.workflows.stale": [
+                [{ status: "PENDING" }, 2],
+                [{ status: "ENQUEUED" }, 0],
+            ],
+            "cortex.dbos.workflows.recovery_attempts.max": [[{}, 7]],
+        });
+        // The stuck workflow ended. The export repeats an attribute set that a
+        // collection leaves out, thus the gauges must fall back to zero here.
+        expect(await collect()).toEqual({
+            "cortex.dbos.workflows.stale": [
+                [{ status: "PENDING" }, 0],
+                [{ status: "ENQUEUED" }, 0],
+            ],
+            "cortex.dbos.workflows.recovery_attempts.max": [[{}, 0]],
+        });
+    });
+
+    it("logs a failed query as a warning and observes nothing", async () => {
+        metrics.setGlobalMeterProvider(provider);
+        __setDbosStateForTest({ launched: true });
+        const logger = createCapturingLogger();
+        const pool = { query: () => Promise.reject(new Error("Connection terminated unexpectedly")) } as unknown as Pool;
+        observeDbosWorkflows({ pool, logger });
+
+        expect(await collect()).toEqual({});
+        expect(logger.records.map((record) => [record.level, record.msg])).toEqual([["warn", "[dbos] workflow health query failed"]]);
+    });
+
+    it("issues no query while metric export is off or DBOS is not launched", async () => {
+        let queries = 0;
+        const pool = {
+            query: () => {
+                queries += 1;
+                return Promise.resolve([{ rows: [] }, { rows: [] }]);
+            },
+        } as unknown as Pool;
+
+        // Metric export off: the boot finds no MeterProvider, thus the gauges
+        // bind to the API no-op meter, which never calls back. A provider that
+        // is registered later does not adopt them.
+        __setDbosStateForTest({ launched: true });
+        observeDbosWorkflows({ pool, logger: silentLogger });
+        metrics.setGlobalMeterProvider(provider);
+        await collect();
+
+        // DBOS not launched: before launch the schema can be absent, and at
+        // shutdown the pool closes before the last export.
+        __setDbosStateForTest({ launched: false });
+        observeDbosWorkflows({ pool, logger: silentLogger });
+        await collect();
+
+        expect(queries).toBe(0);
     });
 });

--- a/harness/src/runtime/dbos.ts
+++ b/harness/src/runtime/dbos.ts
@@ -14,7 +14,8 @@
  */
 
 import { DBOS, type DBOSConfig, type DLogger } from "@dbos-inc/dbos-sdk";
-import type { Pool } from "pg";
+import { metrics } from "@opentelemetry/api";
+import type { Pool, QueryResult } from "pg";
 
 import type { LogFields, Logger } from "../lib/logger.js";
 import { DBOS_SYSTEM_POOL_SIZE } from "./pools.js";
@@ -277,6 +278,137 @@ export async function sweepEphemeralWorkflows({
         }
         logger.error("legacy ephemeral-row sweep failed", { executorID, ...logger.errorFields(err) });
     }
+}
+
+/**
+ * Age at which a PENDING or ENQUEUED workflow counts as stale: 6 h.
+ *
+ * The longest-lived healthy workflow is the parent of an analysis run, which
+ * stays PENDING for the whole run, and `cortex.run.duration` puts its last
+ * finite bucket at 4 h. Six hours clears that bound with margin, so the count
+ * holds only a workflow that no process drives to an end: an orphan of an
+ * executor that is gone, or a body blocked on a message that never arrives. A
+ * workflow that crash-loops is the task of the recovery-attempts gauge, which
+ * does not wait for age.
+ */
+export const STALE_WORKFLOW_AGE_MS = 6 * 60 * 60 * 1000;
+
+/** Server-side cap on the health query, which reads a partial index and takes about a millisecond. */
+const WORKFLOW_HEALTH_STATEMENT_TIMEOUT_MS = 2_000;
+
+/**
+ * Client-side cap on one observation, the wait for a pool connection included.
+ * It sits well inside the 30 s export timeout, so a saturated app pool costs
+ * this gauge one sample and never costs the other instruments their export.
+ */
+const WORKFLOW_HEALTH_OBSERVE_TIMEOUT_MS = 5_000;
+
+/** The non-terminal DBOS statuses, less DELAYED, which waits for its start time by design. */
+const NON_TERMINAL_STATUSES = ["PENDING", "ENQUEUED"] as const;
+type NonTerminalStatus = (typeof NON_TERMINAL_STATUSES)[number];
+
+/**
+ * One grouped read of the non-terminal rows. `SET LOCAL` and the SELECT share
+ * the implicit transaction of one simple-protocol message (no bind values), so
+ * the timeout covers the SELECT and lapses with it on success or on error; the
+ * pooled connection keeps its own setting. `status IN (...)` matches the DBOS
+ * partial index `idx_workflow_status_in_flight`, so the cost follows the
+ * in-flight rows and not the table. `created_at` is epoch milliseconds, read
+ * against the database clock.
+ */
+const WORKFLOW_HEALTH_QUERY = `SET LOCAL statement_timeout = ${WORKFLOW_HEALTH_STATEMENT_TIMEOUT_MS};
+SELECT status,
+       count(*) FILTER (WHERE created_at < (extract(epoch FROM now()) * 1000)::bigint - ${STALE_WORKFLOW_AGE_MS}) AS stale,
+       max(recovery_attempts) AS max_recovery_attempts
+  FROM dbos.workflow_status
+ WHERE status IN ('PENDING', 'ENQUEUED')
+ GROUP BY status`;
+
+/** One row of the health query. `pg` returns a bigint as a string. */
+interface WorkflowHealthRow {
+    readonly status: NonTerminalStatus;
+    readonly stale: string;
+    readonly max_recovery_attempts: string | null;
+}
+
+async function queryWorkflowHealth(pool: Pool): Promise<readonly WorkflowHealthRow[]> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+            () => reject(new Error(`workflow health query exceeded ${WORKFLOW_HEALTH_OBSERVE_TIMEOUT_MS} ms`)),
+            WORKFLOW_HEALTH_OBSERVE_TIMEOUT_MS,
+        );
+    });
+    try {
+        // A message of two statements answers with one result for each; the SELECT is the last.
+        const results = (await Promise.race([pool.query(WORKFLOW_HEALTH_QUERY), deadline])) as unknown as readonly QueryResult<WorkflowHealthRow>[];
+        return results.at(-1)?.rows ?? [];
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+/**
+ * Observe the stuck-workflow gauges on `dbos.workflow_status`, once for each
+ * metric export:
+ *
+ *   - cortex.dbos.workflows.stale{status}          — PENDING and ENQUEUED workflows created more than `STALE_WORKFLOW_AGE_MS` ago
+ *   - cortex.dbos.workflows.recovery_attempts.max  — the highest `recovery_attempts` over PENDING and ENQUEUED workflows of any age
+ *
+ * DBOS increments `recovery_attempts` each time it starts a workflow, so a
+ * workflow that ran once reads 1, and one that every boot recovers climbs
+ * toward the SDK ceiling of 100.
+ *
+ * The table is fleet-wide, thus each replica reports the same values: an
+ * alert aggregates with `max`, never `sum`.
+ *
+ * `status` is the only label. The cumulative export repeats the last value of
+ * an attribute set that a collection does not observe, so every label set is
+ * observed each time, zero included. The workflow names are spread over the
+ * registrations of the harness and of the embedder, thus a name label could
+ * not be observed at zero and a cleared count would never fall. The id of a
+ * stuck workflow comes from the table itself.
+ *
+ * The gauges bind to the global meter, as every harness instrument does. With
+ * metric export off, or under a host that registers no MeterProvider (the
+ * CLI), that is the API no-op meter, which never calls the callback, thus no
+ * query runs. The callback also skips the query while DBOS is not launched:
+ * before launch the schema can be absent, and at shutdown the pool closes
+ * before the last export. A failed query logs a warning and observes nothing,
+ * so the export repeats the last values.
+ */
+export function observeDbosWorkflows({ pool, logger: injected }: { pool: Pool; logger: Logger }): void {
+    const logger = injected.named("dbos");
+    const meter = metrics.getMeter("cortex.dbos");
+    const stale = meter.createObservableGauge("cortex.dbos.workflows.stale", {
+        description: `PENDING or ENQUEUED DBOS workflows created more than ${STALE_WORKFLOW_AGE_MS / 3_600_000} h ago. Tagged by status.`,
+        unit: "{workflow}",
+    });
+    const recoveryAttempts = meter.createObservableGauge("cortex.dbos.workflows.recovery_attempts.max", {
+        description: "Highest recovery_attempts over PENDING and ENQUEUED DBOS workflows. A workflow that ran once reads 1.",
+        unit: "{attempt}",
+    });
+    meter.addBatchObservableCallback(
+        async (observer) => {
+            if (!state.launched) return;
+            let rows: readonly WorkflowHealthRow[];
+            try {
+                rows = await queryWorkflowHealth(pool);
+            } catch (err) {
+                logger.warn("workflow health query failed", logger.errorFields(err));
+                return;
+            }
+            const staleByStatus: Record<NonTerminalStatus, number> = { PENDING: 0, ENQUEUED: 0 };
+            let maxAttempts = 0;
+            for (const row of rows) {
+                staleByStatus[row.status] = Number(row.stale);
+                maxAttempts = Math.max(maxAttempts, Number(row.max_recovery_attempts ?? 0));
+            }
+            for (const status of NON_TERMINAL_STATUSES) observer.observe(stale, staleByStatus[status], { status });
+            observer.observe(recoveryAttempts, maxAttempts);
+        },
+        [stale, recoveryAttempts],
+    );
 }
 
 /** Snapshot of DBOS lifecycle state — read by the readiness probe. */


### PR DESCRIPTION
## What & why

On 2026-08-23 Cortex entered an OOM loop at boot. DBOS recovered the same workflow at each boot, and its `recovery_attempts` increased toward the SDK limit of 100. No signal showed this. `bootHarness` now registers two gauges after the DBOS launch (checklist B8, signal O8, alert A6, decision D-14):

- `cortex.dbos.workflows.stale{status}`: the `PENDING` and `ENQUEUED` workflows that are older than 6 h.
- `cortex.dbos.workflows.recovery_attempts.max`: the highest `recovery_attempts` of those workflows, of all ages. A workflow that ran one time reads 1.

One query feeds the two gauges at each export (60 s):

```sql
SET LOCAL statement_timeout = 2000;
SELECT status,
       count(*) FILTER (WHERE created_at < (extract(epoch FROM now()) * 1000)::bigint - 21600000) AS stale,
       max(recovery_attempts) AS max_recovery_attempts
  FROM dbos.workflow_status
 WHERE status IN ('PENDING', 'ENQUEUED')
 GROUP BY status
```

Notes for the reviewer:

- **Cost.** DBOS 4.23.6 has the partial index `idx_workflow_status_in_flight` on these two statuses. The plan scans that index, thus the cost changes with the number of in-flight rows, not with the size of the table (1.6 ms on a local DBOS schema). The `SET LOCAL` ends with the message, thus the pooled connection keeps its setting. A client limit of 5 s includes the wait for a connection. A failed query logs a warning.
- **6 h.** The parent of an analysis run stays `PENDING` for the full run, and `cortex.run.duration` has its last finite bucket at 4 h. With the 30 m of A6, each run longer than 30 min shows as stale. The recovery gauge finds a crash loop in minutes.
- **Labels.** `status` only, never an id. The cumulative export sends the last value again for a label set that a collection does not observe. The gauge cannot observe each workflow name at zero. Thus, with a name label, a count stays high after the workflow ends.
- **Alert.** Each replica reads the same table. Use `max`, never `sum`: `max(cortex_dbos_workflows_recovery_attempts_max) > 3`, `max(cortex_dbos_workflows_stale) > 0`.
- The gauge sends no query when metric export is off, in the CLI, or while DBOS is not launched.
- **Tests:** the row mapping and the return to zero, a failed query, and no query.

The version does not change. Cortex gets the gauges when it pins the next harness release.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

https://claude.ai/code/session_01G47UrASYb15J6JmG3npn1b
