### PR TITLE
chore(images): add HDO.db to the package-store manifest

### DIFF
--- a/images/package-store/manifest.yaml
+++ b/images/package-store/manifest.yaml
@@ -233,6 +233,11 @@ r:
         - EnhancedVolcano
         - singscore
         - rrvgo
+        - name: HDO.db
+          reason: >
+            The Disease Ontology data that DOSE 4 reads for enrichDO. DOSE
+            comes in as a dependency of clusterProfiler, but its ontology
+            data is a suggested package, thus enrichDO stops without it.
 
         # Network
         - WGCNA


### PR DESCRIPTION
## What & why

The package-store manifest gets one entry, `HDO.db`, beside the enrichment packages. DOSE 4 reads the Disease Ontology from HDO.db, a suggested package that clusterProfiler does not pull in. The catalog farm holds DOSE and not HDO.db, thus `enrichDO` stops with "ontology not supported yet". With the entry, the store build resolves HDO.db into the two lock files. A Disease Ontology template of the knowledge plane can then run in the sandbox.

Notes for the reviewer:

- The manifest is the intent layer. The store pipeline resolves it and commits the lock files back, thus this pull request changes no lock file.
- The manifest already names tximport, and the committed locks do not hold it. The same pipeline run resolves both packages.
- The self-hosted builders were offline at the time of this pull request. A dispatched run queues until a builder starts.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO.
- [x] This PR is focused on a single logical change.
