### PR TITLE
chore(images): add tximport to the package-store manifest

### DIFF
--- a/images/package-store/manifest.yaml
+++ b/images/package-store/manifest.yaml
@@ -225,6 +225,11 @@ r:
         - limma
         - sva
         - variancePartition
+        - name: tximport
+          reason: >
+            The import path of tpl-deseq2-two-group 1.1.0. It summarizes the
+            Salmon and kallisto transcript quantifications to the gene level,
+            and it gives DESeq2 the average transcript lengths as the offset.
 
         # Pathway / enrichment
         - GSVA


### PR DESCRIPTION
## What & why

The package-store manifest gets one entry, `tximport`, beside the count-model packages. The knowledge templates import Salmon and kallisto quantifications with tximport, and the catalog farm does not hold the package. Each quantification test of the templates stops at the library call. With the entry, the store build resolves tximport into the two lock files, and the import path can run in the sandbox.

Notes for the reviewer:

- The entry comes from the knowledge plane branch, where it sat since the Salmon path was completed. The locks never saw it, because no store build ran from that branch.
- The manifest is the intent layer. The store pipeline resolves it and commits the lock files back, thus this pull request changes no lock file.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO.
- [x] This PR is focused on a single logical change.
